### PR TITLE
Handle gb2312 charset with simplifiedchinese.GBK

### DIFF
--- a/charset/charset.go
+++ b/charset/charset.go
@@ -16,7 +16,7 @@ import (
 var charsets = map[string]encoding.Encoding{
 	"big5":         traditionalchinese.Big5,
 	"euc-jp":       japanese.EUCJP,
-	"gb2312":       simplifiedchinese.HZGB2312,
+	"gb2312":       simplifiedchinese.GBK,
 	"iso-2022-jp":  japanese.ISO2022JP,
 	"iso-8859-1":   charmap.ISO8859_1,
 	"iso-8859-2":   charmap.ISO8859_2,

--- a/charset/charset_test.go
+++ b/charset/charset_test.go
@@ -35,6 +35,11 @@ var testCharsets = []struct {
 		charset: "idontexist",
 		encoded: []byte{42},
 	},
+	{
+		charset: "gb2312",
+		encoded: []byte{178, 226, 202, 212},
+		decoded: "测试",
+	},
 }
 
 func TestCharsetReader(t *testing.T) {


### PR DESCRIPTION
Charset error happens when I try to fetch an e-mail with 'charset=gb2312'. I found that this charset is handled with simplifiedchinese.HZGB2312.  All going well with simplifiedchinese.GBK now.