### PR TITLE
Add windows-1250 encoding

### DIFF
--- a/charset/charset.go
+++ b/charset/charset.go
@@ -29,6 +29,7 @@ var charsets = map[string]encoding.Encoding{
 	"iso-8859-16":  charmap.ISO8859_16,
 	"koi8-r":       charmap.KOI8R,
 	"shift_jis":    japanese.ShiftJIS,
+	"windows-1250": charmap.Windows1250,
 	"windows-1251": charmap.Windows1251,
 	"windows-1252": charmap.Windows1252,
 }

--- a/charset/charset_test.go
+++ b/charset/charset_test.go
@@ -22,6 +22,11 @@ var testCharsets = []struct {
 		decoded: "café",
 	},
 	{
+		charset: "windows-1250",
+		encoded: []byte{0x8c, 0x8d, 0x8f, 0x9c, 0x9d, 0x9f, 0xbc, 0xbe},
+		decoded: "ŚŤŹśťźĽľ",
+	},
+	{
 		charset: "windows-1252",
 		encoded: []byte{0x63, 0x61, 0x66, 0xE9, 0x20, 0x80},
 		decoded: "café €",


### PR DESCRIPTION
I needed this for decoding some old messages. It would be nice if
https://github.com/emersion/go-message/blob/master/entity.go#L25 returned an
error if the encoding wasn't found.