### PR TITLE
fix 'unhandled charset "cp1252"' error

### DIFF
--- a/charset/charset.go
+++ b/charset/charset.go
@@ -14,27 +14,30 @@ import (
 )
 
 var charsets = map[string]encoding.Encoding{
-	"big5":         traditionalchinese.Big5,
-	"euc-jp":       japanese.EUCJP,
-	"gbk":          simplifiedchinese.GBK,
-	"gb2312":       simplifiedchinese.GBK,     // as GBK is a superset of HZGB2312, so just use GBK
-	"gb18030":      simplifiedchinese.GB18030, // GB18030 Use for parse QQ business mail message
-	"iso-2022-jp":  japanese.ISO2022JP,
-	"iso-8859-1":   charmap.ISO8859_1,
-	"iso-8859-2":   charmap.ISO8859_2,
-	"iso-8859-3":   charmap.ISO8859_3,
-	"iso-8859-4":   charmap.ISO8859_4,
-	"iso-8859-9":   charmap.ISO8859_9,
-	"iso-8859-10":  charmap.ISO8859_10,
-	"iso-8859-13":  charmap.ISO8859_13,
-	"iso-8859-14":  charmap.ISO8859_14,
-	"iso-8859-15":  charmap.ISO8859_15,
-	"iso-8859-16":  charmap.ISO8859_16,
-	"koi8-r":       charmap.KOI8R,
-	"shift_jis":    japanese.ShiftJIS,
-	"windows-1250": charmap.Windows1250,
-	"windows-1251": charmap.Windows1251,
-	"windows-1252": charmap.Windows1252,
+	"big5":             traditionalchinese.Big5,
+	"euc-jp":           japanese.EUCJP,
+	"gbk":              simplifiedchinese.GBK,
+	"gb2312":           simplifiedchinese.GBK,     // as GBK is a superset of HZGB2312, so just use GBK
+	"gb18030":          simplifiedchinese.GB18030, // GB18030 Use for parse QQ business mail message
+	"iso-2022-jp":      japanese.ISO2022JP,
+	"iso-8859-1":       charmap.ISO8859_1,
+	"iso-8859-2":       charmap.ISO8859_2,
+	"iso-8859-3":       charmap.ISO8859_3,
+	"iso-8859-4":       charmap.ISO8859_4,
+	"iso-8859-9":       charmap.ISO8859_9,
+	"iso-8859-10":      charmap.ISO8859_10,
+	"iso-8859-13":      charmap.ISO8859_13,
+	"iso-8859-14":      charmap.ISO8859_14,
+	"iso-8859-15":      charmap.ISO8859_15,
+	"iso-8859-16":      charmap.ISO8859_16,
+	"koi8-r":           charmap.KOI8R,
+	"shift_jis":        japanese.ShiftJIS,
+	"windows-1250":     charmap.Windows1250,
+	"windows-1251":     charmap.Windows1251,
+	"windows-1252":     charmap.Windows1252,
+	"cp1250":           charmap.Windows1250,
+	"cp1251":           charmap.Windows1251,
+	"cp1252":           charmap.Windows1252,
 	"ansi_x3.110-1983": charmap.ISO8859_1,
 }
 


### PR DESCRIPTION
Some emails have a windows encoding specified in the format "cp*"