### PR TITLE
Fix reader_test.go

### DIFF
--- a/mail/reader_test.go
+++ b/mail/reader_test.go
@@ -32,10 +32,10 @@ func ExampleReader() {
 		switch h := p.Header.(type) {
 		case mail.TextHeader:
 			b, _ := ioutil.ReadAll(p.Body)
-			log.Println("Got text: %v", string(b))
+			log.Printf("Got text: %v", string(b))
 		case mail.AttachmentHeader:
 			filename, _ := h.Filename()
-			log.Println("Got attachment: %v", filename)
+			log.Printf("Got attachment: %v", filename)
 		}
 	}
 }


### PR DESCRIPTION
go test fails because of this:
./reader_test.go:35:4: Println call has possible formatting directive %v
./reader_test.go:38:4: Println call has possible formatting directive %v