### PR TITLE
Support ANSI x3.4 as a name for ASCII

### DIFF
--- a/charset/charset.go
+++ b/charset/charset.go
@@ -49,7 +49,8 @@ func init() {
 // Reader returns an io.Reader that converts the provided charset to UTF-8.
 func Reader(charset string, input io.Reader) (io.Reader, error) {
 	charset = strings.ToLower(charset)
-	// QUIRK: "ascii" and "utf8" are not in the spec but are common
+	// QUIRK: "ascii" and "utf8" are not in the spec but are common. The
+	// names ANSI_X3.4-{1968,1986} are historical and recognized as aliases
 	if charset == "utf-8" || charset == "utf8" || charset == "us-ascii" || charset == "ascii" || strings.HasPrefix(charset, "ansi_x3.4-") {
 		return input, nil
 	}

--- a/charset/charset.go
+++ b/charset/charset.go
@@ -50,7 +50,7 @@ func init() {
 func Reader(charset string, input io.Reader) (io.Reader, error) {
 	charset = strings.ToLower(charset)
 	// QUIRK: "ascii" and "utf8" are not in the spec but are common
-	if charset == "utf-8" || charset == "utf8" || charset == "us-ascii" || charset == "ascii" {
+	if charset == "utf-8" || charset == "utf8" || charset == "us-ascii" || charset == "ascii" || strings.HasPrefix(charset, "ansi_x3.4-") {
 		return input, nil
 	}
 	if enc, ok := charsets[charset]; ok {


### PR DESCRIPTION
Hi there! When using [aerc](https://git.sr.ht/~sircmpwn/aerc), I noticed that some messages in my inbox had declared their encoding "ansi_x3.4-1968", which resulted in some errors trying to decode them. It turns out this is just another possible name for ASCII. This patch allows any "ansi_x3.4-" name as a synonym for ASCII. When I apply this and build aerc, my issue is fixed.

Let me know if you have any suggestions!