### PR TITLE
mail/header: strip CFWS from date headers.

### DIFF
--- a/mail/header.go
+++ b/mail/header.go
@@ -2,12 +2,18 @@ package mail
 
 import (
 	"net/mail"
+	"regexp"
 	"time"
 
 	"github.com/emersion/go-message"
 )
 
 const dateLayout = "Mon, 02 Jan 2006 15:04:05 -0700"
+
+// TODO: this is a blunt way to strip any trailing CFWS (comment). A sharper
+// one would strip multiple CFWS, and only if really valid according to
+// RFC5322.
+var commentRE = regexp.MustCompile(`[ \t]+\(.*\)$`)
 
 // A Header is a mail header.
 type Header struct {
@@ -31,7 +37,10 @@ func (h *Header) SetAddressList(key string, addrs []*Address) {
 
 // Date parses the Date header field.
 func (h *Header) Date() (time.Time, error) {
-	return mail.ParseDate(h.Get("Date"))
+	//TODO: remove this once https://go-review.googlesource.com/c/go/+/117596/
+	// is merged
+	date := commentRE.ReplaceAllString(h.Get("Date"), "")
+	return mail.ParseDate(date)
 }
 
 // SetDate formats the Date header field.

--- a/mail/header_test.go
+++ b/mail/header_test.go
@@ -42,3 +42,20 @@ func TestHeader(t *testing.T) {
 		t.Errorf("Expected header subject to be %v, but got %v", subject, got)
 	}
 }
+
+func TestCFWSDates(t *testing.T) {
+	tc := []string{
+		"Mon, 22 Jul 2019 13:57:29 -0500 (GMT-05:00)",
+		"Mon, 22 Jul 2019 13:57:29 -0500",
+		"Mon, 2 Jan 06 15:04:05 MST (Some random stuff)",
+		"Mon, 2 Jan 06 15:04:05 MST",
+	}
+	var h mail.Header
+	for _, tt := range tc {
+		h.Set("Date", tt)
+		_, err := h.Date()
+		if err != nil {
+			t.Errorf("Failed to parse time %q: %v", tt, err)
+		}
+	}
+}


### PR DESCRIPTION
I think that should be it, at least from the stuff that's in header.go.

As far as I understood the RFC, subject must not have a cfws and the Address fields are already parsed by the go stdlib.