### PR TITLE
Add error on invalid header name characters

### DIFF
--- a/textproto/header.go
+++ b/textproto/header.go
@@ -309,88 +309,9 @@ func isSpace(c byte) bool {
 	return c == ' ' || c == '\t'
 }
 
-func validHeaderFieldByte(b byte) bool {
-	return int(b) < len(isTokenTable) && isTokenTable[b]
-}
-
-var isTokenTable = [127]bool{
-	'!':  true,
-	'#':  true,
-	'$':  true,
-	'%':  true,
-	'&':  true,
-	'\'': true,
-	'*':  true,
-	'+':  true,
-	'-':  true,
-	'.':  true,
-	'0':  true,
-	'1':  true,
-	'2':  true,
-	'3':  true,
-	'4':  true,
-	'5':  true,
-	'6':  true,
-	'7':  true,
-	'8':  true,
-	'9':  true,
-	'A':  true,
-	'B':  true,
-	'C':  true,
-	'D':  true,
-	'E':  true,
-	'F':  true,
-	'G':  true,
-	'H':  true,
-	'I':  true,
-	'J':  true,
-	'K':  true,
-	'L':  true,
-	'M':  true,
-	'N':  true,
-	'O':  true,
-	'P':  true,
-	'Q':  true,
-	'R':  true,
-	'S':  true,
-	'T':  true,
-	'U':  true,
-	'W':  true,
-	'V':  true,
-	'X':  true,
-	'Y':  true,
-	'Z':  true,
-	'^':  true,
-	'_':  true,
-	'`':  true,
-	'a':  true,
-	'b':  true,
-	'c':  true,
-	'd':  true,
-	'e':  true,
-	'f':  true,
-	'g':  true,
-	'h':  true,
-	'i':  true,
-	'j':  true,
-	'k':  true,
-	'l':  true,
-	'm':  true,
-	'n':  true,
-	'o':  true,
-	'p':  true,
-	'q':  true,
-	'r':  true,
-	's':  true,
-	't':  true,
-	'u':  true,
-	'v':  true,
-	'w':  true,
-	'x':  true,
-	'y':  true,
-	'z':  true,
-	'|':  true,
-	'~':  true,
+func validHeaderKeyByte(b byte) bool {
+	c := int(b)
+	return c >= 33 && c <= 126 && c != ':'
 }
 
 // trim returns s with leading and trailing spaces and tabs removed.
@@ -524,16 +445,17 @@ func ReadHeader(r *bufio.Reader) (Header, error) {
 			return newHeader(fs), fmt.Errorf("message: malformed MIME header line: %v", string(kv))
 		}
 
-		key_bytes := trim(kv[:i])
+		keyBytes := trim(kv[:i])
 
 		// Verify that there are no invalid characters in the header key.
-		for _, c := range key_bytes {
-			if !validHeaderFieldByte(c) {
-				return newHeader(fs), fmt.Errorf("message: malformed MIME header line: %v", string(kv))
+		// See RFC 5322 Section 2.2
+		for _, c := range keyBytes {
+			if !validHeaderKeyByte(c) {
+				return newHeader(fs), fmt.Errorf("message: malformed MIME header key: %v", string(keyBytes))
 			}
 		}
 
-		key := textproto.CanonicalMIMEHeaderKey(string(key_bytes))
+		key := textproto.CanonicalMIMEHeaderKey(string(keyBytes))
 
 		// As per RFC 7230 field-name is a token, tokens consist of one or more
 		// chars. We could return a an error here, but better to be liberal in

--- a/textproto/header.go
+++ b/textproto/header.go
@@ -309,6 +309,90 @@ func isSpace(c byte) bool {
 	return c == ' ' || c == '\t'
 }
 
+func validHeaderFieldByte(b byte) bool {
+	return int(b) < len(isTokenTable) && isTokenTable[b]
+}
+
+var isTokenTable = [127]bool{
+	'!':  true,
+	'#':  true,
+	'$':  true,
+	'%':  true,
+	'&':  true,
+	'\'': true,
+	'*':  true,
+	'+':  true,
+	'-':  true,
+	'.':  true,
+	'0':  true,
+	'1':  true,
+	'2':  true,
+	'3':  true,
+	'4':  true,
+	'5':  true,
+	'6':  true,
+	'7':  true,
+	'8':  true,
+	'9':  true,
+	'A':  true,
+	'B':  true,
+	'C':  true,
+	'D':  true,
+	'E':  true,
+	'F':  true,
+	'G':  true,
+	'H':  true,
+	'I':  true,
+	'J':  true,
+	'K':  true,
+	'L':  true,
+	'M':  true,
+	'N':  true,
+	'O':  true,
+	'P':  true,
+	'Q':  true,
+	'R':  true,
+	'S':  true,
+	'T':  true,
+	'U':  true,
+	'W':  true,
+	'V':  true,
+	'X':  true,
+	'Y':  true,
+	'Z':  true,
+	'^':  true,
+	'_':  true,
+	'`':  true,
+	'a':  true,
+	'b':  true,
+	'c':  true,
+	'd':  true,
+	'e':  true,
+	'f':  true,
+	'g':  true,
+	'h':  true,
+	'i':  true,
+	'j':  true,
+	'k':  true,
+	'l':  true,
+	'm':  true,
+	'n':  true,
+	'o':  true,
+	'p':  true,
+	'q':  true,
+	'r':  true,
+	's':  true,
+	't':  true,
+	'u':  true,
+	'v':  true,
+	'w':  true,
+	'x':  true,
+	'y':  true,
+	'z':  true,
+	'|':  true,
+	'~':  true,
+}
+
 // trim returns s with leading and trailing spaces and tabs removed.
 // It does not assume Unicode or UTF-8.
 func trim(s []byte) []byte {
@@ -440,7 +524,16 @@ func ReadHeader(r *bufio.Reader) (Header, error) {
 			return newHeader(fs), fmt.Errorf("message: malformed MIME header line: %v", string(kv))
 		}
 
-		key := textproto.CanonicalMIMEHeaderKey(string(trim(kv[:i])))
+		key_bytes := trim(kv[:i])
+
+		// Verify that there are no invalid characters in the header key.
+		for _, c := range key_bytes {
+			if !validHeaderFieldByte(c) {
+				return newHeader(fs), fmt.Errorf("message: malformed MIME header line: %v", string(kv))
+			}
+		}
+
+		key := textproto.CanonicalMIMEHeaderKey(string(key_bytes))
 
 		// As per RFC 7230 field-name is a token, tokens consist of one or more
 		// chars. We could return a an error here, but better to be liberal in

--- a/textproto/header_test.go
+++ b/textproto/header_test.go
@@ -205,6 +205,23 @@ func TestReadHeader(t *testing.T) {
 	}
 }
 
+const testInvalidHeader = "Received: from example.com by example.org\r\n" +
+	"Received: from localhost by example.com\r\n" +
+	"To: Taki Tachibana <taki.tachibana@example.org>\r\n" +
+	"From: Mitsuha Miyamizu <mitsuha.miyamizu@example.com>\r\n" +
+	"not valid: example\r\n"
+
+func TestInvalidHeader(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader(testInvalidHeader))
+	_, err := ReadHeader(r)
+	if err == nil {
+		t.Errorf("No error thrown")
+		// Header is invalid because header name contains a space
+	} else if !strings.HasSuffix(err.Error(), "not valid: example\r\n") {
+		t.Errorf("Improper error thrown: %v", err)
+	}
+}
+
 const testHeaderWithoutBody = "Received: from example.com by example.org\r\n" +
 	"Received: from localhost by example.com\r\n" +
 	"To: Taki Tachibana <taki.tachibana@example.org>\r\n" +

--- a/textproto/header_test.go
+++ b/textproto/header_test.go
@@ -205,20 +205,13 @@ func TestReadHeader(t *testing.T) {
 	}
 }
 
-const testInvalidHeader = "Received: from example.com by example.org\r\n" +
-	"Received: from localhost by example.com\r\n" +
-	"To: Taki Tachibana <taki.tachibana@example.org>\r\n" +
-	"From: Mitsuha Miyamizu <mitsuha.miyamizu@example.com>\r\n" +
-	"not valid: example\r\n"
+const testInvalidHeader = "not valid: example\r\n"
 
 func TestInvalidHeader(t *testing.T) {
 	r := bufio.NewReader(strings.NewReader(testInvalidHeader))
 	_, err := ReadHeader(r)
 	if err == nil {
 		t.Errorf("No error thrown")
-		// Header is invalid because header name contains a space
-	} else if !strings.HasSuffix(err.Error(), "not valid: example\r\n") {
-		t.Errorf("Improper error thrown: %v", err)
 	}
 }
 


### PR DESCRIPTION
Textproto should throw an error and fail to parse a header if it
contains an invalid rather than preserving it as-is.

References: https://github.com/emersion/go-message/issues/68

I have very little Go experience, so let me know if there's any issues with this fix or if anything is non-idiomatic. I'm happy to clean things up :)