### PR TITLE
mail: add Header.MessageID and Header.MsgIDList

### DIFF
--- a/mail/header.go
+++ b/mail/header.go
@@ -261,3 +261,40 @@ func (h *Header) Subject() (string, error) {
 func (h *Header) SetSubject(s string) {
 	h.SetText("Subject", s)
 }
+
+// MessageID parses the Message-ID field. It returns the message identifier,
+// without the angle brackets. If the message doesn't have a Message-ID header
+// field, it returns an empty string.
+func (h *Header) MessageID() (string, error) {
+	v := h.Get("Message-Id")
+	if v == "" {
+		return "", nil
+	}
+
+	p := headerParser{v}
+	return p.parseMsgID()
+}
+
+// MsgIDList parses a list of message identifiers. It returns message
+// identifiers without angle brackets. If the header field is missing, it
+// returns nil.
+//
+// This can be used on In-Reply-To and References header fields.
+func (h *Header) MsgIDList(key string) ([]string, error) {
+	v := h.Get(key)
+	if v == "" {
+		return nil, nil
+	}
+
+	p := headerParser{v}
+	var l []string
+	for !p.empty() {
+		msgID, err := p.parseMsgID()
+		if err != nil {
+			return l, err
+		}
+		l = append(l, msgID)
+	}
+
+	return l, nil
+}


### PR DESCRIPTION
Those are defined in RFC 5322 section 3.6.4. We need to provide helpers
because the fields may contain CFWS.

~~We just use mail.ParseAddress and mail.ParseAddressList to avoid
building a msg-id parser. Maybe it's desirable to add a msg-id parser
upstream in net/mail.~~

Message identifiers are returned without the angle brackets, because the
RFC says:

> Semantically, the angle bracket characters are not part of the
> msg-id; the msg-id is what is contained between the two angle bracket
> characters.

Also, it's easier for the caller to add back the angle brackets if
needed rather than stripping them.

MsgIDList isn't the best name ever. The RFC defines the message-id token
for the Message-ID header field and the msg-id token for message
identifiers, hence this name. I wonder if we can come up with something
better.

Maybe we should add Header.SetMessageID and Header.SetMsgIDList. Maybe
we should remove our existing GenerateMessageID function, and add it to
Header.

[1]: https://tools.ietf.org/html/rfc5322#section-3.6.4

References: https://github.com/emersion/go-message/issues/49