### PR TITLE
textproto: Add limits for header field length and total amount of fields

### DIFF
--- a/textproto/header.go
+++ b/textproto/header.go
@@ -308,7 +308,7 @@ func readLineSlice(r *bufio.Reader, line []byte) ([]byte, error) {
 
 		line = append(line, l...)
 
-		if len(line) > MaxLineOctets {
+		if len(line) > maxLineOctets {
 			return nil, TooBigError{"line"}
 		}
 
@@ -422,16 +422,8 @@ func trimAroundNewlines(v []byte) string {
 }
 
 const (
-	MaxHeaderLines = 1000
-
-	// MaxLineOctets is the maximum length of line in the header in bytes (octets).
-	//
-	// The max length in RFC 5322 is 1000 **charcters** (including CRLF).
-	// In the edge case:
-	// \tUTF-8 4-byte chars...CRLF
-	// That is. 3 ASCII characters and 997 left for value which can be
-	// UTF-8 up to 3988 bytes. This gives 3991 bytes in the whole line.
-	MaxLineOctets = 3991
+	maxHeaderLines = 1000
+	maxLineOctets  = 4000
 )
 
 // ReadHeader reads a MIME header from r. The header is a sequence of possibly
@@ -449,7 +441,7 @@ func ReadHeader(r *bufio.Reader) (Header, error) {
 		return newHeader(fs), fmt.Errorf("message: malformed MIME header initial line: %v", string(line))
 	}
 
-	maxLines := MaxHeaderLines
+	maxLines := maxHeaderLines
 
 	for {
 		var (

--- a/textproto/header_test.go
+++ b/textproto/header_test.go
@@ -215,6 +215,32 @@ func TestInvalidHeader(t *testing.T) {
 	}
 }
 
+func TestReadHeader_TooBig(t *testing.T) {
+	testHeader := "Received: from example.com by example.org\r\n" +
+		"Received: from localhost by example.com\r\n" +
+		"To: Taki Tachibana <taki.tachibana@example.org> " + strings.Repeat("A", 4000) + "\r\n" +
+		"From: Mitsuha Miyamizu <mitsuha.miyamizu@example.com>\r\n\r\n"
+	_, err := ReadHeader(bufio.NewReader(strings.NewReader(testHeader)))
+	if err == nil {
+		t.Fatalf("ReadHeader() succeeded")
+	}
+	if _, ok := err.(TooBigError); !ok {
+		t.Fatalf("Not TooBigError returned: %T", err)
+	}
+
+	testHeader = "Received: from example.com by example.org\r\n" +
+		"Received: from localhost by example.com\r\n" +
+		"To: Taki Tachibana <taki.tachibana@example.org>\r\n" +
+		strings.Repeat("From: Mitsuha Miyamizu <mitsuha.miyamizu@example.com>\r\n", 1001) + "\r\n"
+	_, err = ReadHeader(bufio.NewReader(strings.NewReader(testHeader)))
+	if err == nil {
+		t.Fatalf("ReadHeader() succeeded")
+	}
+	if _, ok := err.(TooBigError); !ok {
+		t.Fatalf("Not TooBigError returned: %T", err)
+	}
+}
+
 const testHeaderWithoutBody = "Received: from example.com by example.org\r\n" +
 	"Received: from localhost by example.com\r\n" +
 	"To: Taki Tachibana <taki.tachibana@example.org>\r\n" +


### PR DESCRIPTION
Limits specified allow header sections with total size up to ~3.8 MiB.
This should be enough for literally any message.

Closes #28.
Related to foxcpp/maddy#118.