### PR TITLE
mail: add msg-id setters

### DIFF
--- a/mail/header.go
+++ b/mail/header.go
@@ -1,15 +1,20 @@
 package mail
 
 import (
+	"bytes"
+	"crypto/rand"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"net/mail"
+	"os"
 	"regexp"
 	"strings"
 	"time"
 	"unicode/utf8"
 
 	"github.com/emersion/go-message"
+	"github.com/martinlindhe/base36"
 )
 
 const dateLayout = "Mon, 02 Jan 2006 15:04:05 -0700"
@@ -297,4 +302,26 @@ func (h *Header) MsgIDList(key string) ([]string, error) {
 	}
 
 	return l, nil
+}
+
+// GenerateMessageID generates an RFC 2822-compliant Message-Id based on the
+// informational draft "Recommendations for generating Message IDs", for lack
+// of a better authoritative source.
+func (h *Header) GenerateMessageID() error {
+	now := bytes.NewBuffer(make([]byte, 0, 8))
+	binary.Write(now, binary.BigEndian, time.Now().UnixNano())
+
+	nonce := make([]byte, 8)
+	if _, err := rand.Read(nonce); err != nil {
+		return err
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+
+	msgID := fmt.Sprintf("<%s.%s@%s>", base36.EncodeBytes(now.Bytes()), base36.EncodeBytes(nonce), hostname)
+	h.Set("Message-Id", msgID)
+	return nil
 }

--- a/mail/header.go
+++ b/mail/header.go
@@ -325,3 +325,15 @@ func (h *Header) GenerateMessageID() error {
 	h.Set("Message-Id", msgID)
 	return nil
 }
+
+// SetMsgIDList formats a list of message identifiers. Message identifiers
+// don't include angle brackets.
+//
+// This can be used on In-Reply-To and References header fields.
+func (h *Header) SetMsgIDList(key string, l []string) {
+	var v string
+	if len(l) > 0 {
+		v = "<" + strings.Join(l, "> <") + ">"
+	}
+	h.Set(key, v)
+}

--- a/mail/header_test.go
+++ b/mail/header_test.go
@@ -127,3 +127,13 @@ func TestHeader_MsgIDList(t *testing.T) {
 		}
 	}
 }
+
+func TestHeader_GenerateMessageID(t *testing.T) {
+	var h mail.Header
+	if err := h.GenerateMessageID(); err != nil {
+		t.Fatalf("Header.GenerateMessageID() = %v", err)
+	}
+	if _, err := h.MessageID(); err != nil {
+		t.Errorf("Failed to parse generated Message-Id: Header.MessageID() = %v", err)
+	}
+}

--- a/mail/header_test.go
+++ b/mail/header_test.go
@@ -137,3 +137,22 @@ func TestHeader_GenerateMessageID(t *testing.T) {
 		t.Errorf("Failed to parse generated Message-Id: Header.MessageID() = %v", err)
 	}
 }
+
+func TestHeader_SetMsgIDList(t *testing.T) {
+	tests := []struct {
+		raw    string
+		msgIDs []string
+	}{
+		{"", nil},
+		{"<123@asdf>", []string{"123@asdf"}},
+		{"<123@asdf> <456@asdf>", []string{"123@asdf", "456@asdf"}},
+	}
+	for _, test := range tests {
+		var h mail.Header
+		h.SetMsgIDList("In-Reply-To", test.msgIDs)
+		raw := h.Get("In-Reply-To")
+		if raw != test.raw {
+			t.Errorf("Failed to format In-Reply-To %q: Header.Get() = %q, want %q", test.msgIDs, raw, test.raw)
+		}
+	}
+}

--- a/mail/mail.go
+++ b/mail/mail.go
@@ -7,34 +7,3 @@
 //
 // RFC 5322 defines the Internet Message Format.
 package mail
-
-import (
-	"bytes"
-	"crypto/rand"
-	"encoding/binary"
-	"fmt"
-	"os"
-	"time"
-
-	"github.com/martinlindhe/base36"
-)
-
-// GenerateMessageID generates an RFC 2822-compliant Message-ID based on the
-// informational draft "Recommendations for generating Message IDs", for lack
-// of a better authoritative source.
-func GenerateMessageID() string {
-	var (
-		now   bytes.Buffer
-		nonce []byte = make([]byte, 8)
-	)
-	binary.Write(&now, binary.BigEndian, time.Now().UnixNano())
-	rand.Read(nonce)
-	hostname, err := os.Hostname()
-	if err != nil {
-		hostname = "localhost"
-	}
-	return fmt.Sprintf("<%s.%s@%s>",
-		base36.EncodeBytes(now.Bytes()),
-		base36.EncodeBytes(nonce),
-		hostname)
-}

--- a/mail/mail_test.go
+++ b/mail/mail_test.go
@@ -1,12 +1,5 @@
 package mail_test
 
-import (
-	"regexp"
-	"testing"
-
-	"github.com/emersion/go-message/mail"
-)
-
 const mailString = "Subject: Your Name\r\n" +
 	"Content-Type: multipart/mixed; boundary=message-boundary\r\n" +
 	"\r\n" +
@@ -40,11 +33,3 @@ const nestedMailString = "Subject: Fwd: Your Name\r\n" +
 	"\r\n" +
 	mailString +
 	"--outer-message-boundary--\r\n"
-
-func TestGenerateMessageID(t *testing.T) {
-	msgId := mail.GenerateMessageID()
-	regex := regexp.MustCompile(`^<.*@.*>$`)
-	if !regex.MatchString(msgId) {
-		t.Error("Generated message ID does not meet RFC requirement")
-	}
-}


### PR DESCRIPTION
See each commit.

Should we add `SetMessageID`, or wait till someone needs it?

cc @foxcpp 