### PR TITLE
Add CreateInlineWriter, allowing alternatives, but no attachments

### DIFF
--- a/mail/writer.go
+++ b/mail/writer.go
@@ -51,6 +51,20 @@ func CreateWriter(w io.Writer, header Header) (*Writer, error) {
 	return &Writer{mw}, nil
 }
 
+// CreateInlineWriter writes a mail header to w. The mail will contain an
+// inline part, allowing to represent the same text in different formats.
+// Attachments cannot be included.
+func CreateInlineWriter(w io.Writer, header Header) (*InlineWriter, error) {
+	header.Set("Content-Type", "multipart/alternative")
+
+	mw, err := message.CreateWriter(w, header.Header)
+	if err != nil {
+		return nil, err
+	}
+
+	return &InlineWriter{mw}, nil
+}
+
 // CreateSingleInlineWriter writes a mail header to w. The mail will contain a
 // single inline part. The body of the part should be written to the returned
 // io.WriteCloser. Only one single inline part should be written, use


### PR DESCRIPTION
`CreateWriter` does set Content-Type to `multipart/mixed` unconditionally.
This forces some mail clients into showing that attachments exist -- even if there are none (the multipart only contains one part).

As I still need a `multipart/alternative`, using `CreateSingleInlineWriter` is not sufficient. Thus I added `CreateInlineWriter` (returning an `*InlineWriter`) as the (missing) middle course.