### PR TITLE
Remove hz-gb-2312 encoding as it can crash

### DIFF
--- a/charset/charset.go
+++ b/charset/charset.go
@@ -35,9 +35,11 @@ var charsets = map[string]encoding.Encoding{
 
 	"ansi_x3.110-1983": charmap.ISO8859_1,     // see RFC 1345 page 62, mostly superset of ISO 8859-1
 	"gb2312":           simplifiedchinese.GBK, // GBK is a superset of HZGB2312
-	"cp1250":           charmap.Windows1250,
-	"cp1251":           charmap.Windows1251,
-	"cp1252":           charmap.Windows1252,
+	// disabled due to https://github.com/emersion/go-message/issues/95
+	"hz-gb-2312": nil,
+	"cp1250":     charmap.Windows1250,
+	"cp1251":     charmap.Windows1251,
+	"cp1252":     charmap.Windows1252,
 }
 
 func init() {

--- a/charset/charset_test.go
+++ b/charset/charset_test.go
@@ -3,6 +3,7 @@ package charset
 import (
 	"bytes"
 	"io/ioutil"
+	"strings"
 	"testing"
 )
 
@@ -69,5 +70,17 @@ func TestCharsetReader(t *testing.T) {
 				t.Errorf("Expected decoded text to be %q but got %q", test.decoded, s)
 			}
 		}
+	}
+}
+
+func TestDisabledCharsetReader(t *testing.T) {
+	_, err := Reader("hz-gb-2312", strings.NewReader("Some dummy text"))
+	if err == nil {
+		t.Errorf("%v encoding is disabled and should give an error", "hz-gb-2312")
+		return
+	}
+	if !strings.HasSuffix(err.Error(), "unsupported charset") {
+		t.Errorf("expected error to end in 'unsupported charset', got %v",
+			err.Error())
 	}
 }


### PR DESCRIPTION
Upstream go's x/text/encoding package has a bug that makes the
'hz-gb-2312' encoding crash (https://github.com/golang/go/issues/35118)

This was reported to go-message in
https://github.com/emersion/go-message/issues/95

This commit removes the offending encoding so that go-message can't crash if
people import the charset package. It should be reverted once the upstream
package is fixed by the go developers.