### PR TITLE
message: introduce Entity.Walk

### DIFF
--- a/entity_test.go
+++ b/entity_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -47,7 +48,7 @@ func testMakeMultipart() *Entity {
 	return e
 }
 
-const testMultipartHeader = "Mime-Version: 1.0\r\n"+
+const testMultipartHeader = "Mime-Version: 1.0\r\n" +
 	"Content-Type: multipart/alternative; boundary=IMTHEBOUNDARY\r\n\r\n"
 
 const testMultipartBody = "--IMTHEBOUNDARY\r\n" +
@@ -258,5 +259,87 @@ func TestNewEntity_MultipartReader_notMultipart(t *testing.T) {
 	mr := e.MultipartReader()
 	if mr != nil {
 		t.Fatal("(non-multipart).MultipartReader() != nil")
+	}
+}
+
+type testWalkPart struct {
+	path      []int
+	mediaType string
+	body      string
+	err       error
+}
+
+func walkCollect(e *Entity) ([]testWalkPart, error) {
+	var l []testWalkPart
+	err := e.Walk(func(path []int, part *Entity, err error) error {
+		var body string
+		if part.MultipartReader() == nil {
+			b, err := ioutil.ReadAll(part.Body)
+			if err != nil {
+				return err
+			}
+			body = string(b)
+		}
+		mediaType, _, _ := part.Header.ContentType()
+		l = append(l, testWalkPart{
+			path:      path,
+			mediaType: mediaType,
+			body:      body,
+			err:       err,
+		})
+		return nil
+	})
+	return l, err
+}
+
+func TestWalk_single(t *testing.T) {
+	e, err := Read(strings.NewReader(testSingleText))
+	if err != nil {
+		t.Fatalf("Read() = %v", err)
+	}
+
+	want := []testWalkPart{{
+		path:      nil,
+		mediaType: "text/plain",
+		body:      "Message body",
+	}}
+
+	got, err := walkCollect(e)
+	if err != nil {
+		t.Fatalf("Entity.Walk() = %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Entity.Walk() =\n%#v\nbut want:\n%#v", got, want)
+	}
+}
+
+func TestWalk_multipart(t *testing.T) {
+	e := testMakeMultipart()
+
+	want := []testWalkPart{
+		{
+			path:      nil,
+			mediaType: "multipart/alternative",
+		},
+		{
+			path:      []int{0},
+			mediaType: "text/plain",
+			body:      "Text part",
+		},
+		{
+			path:      []int{1},
+			mediaType: "text/html",
+			body:      "<p>HTML part</p>",
+		},
+	}
+
+	got, err := walkCollect(e)
+	if err != nil {
+		t.Fatalf("Entity.Walk() = %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Entity.Walk() =\n%#v\nbut want:\n%#v", got, want)
 	}
 }


### PR DESCRIPTION
Entity.Walk is similar to filepath.Walk [1]: it iterates over all parts
in the entity tree.

There is no equivalent to SkipDir, because the whole tree will need to
be read anyway (ie. the performance benefits of filepath.SkipDir cannot
apply here).

WalkFunc paths are different from IMAP part paths: the root part
doesn't have a path equal to {1}, and indices start at 0. The former is
necessary to disambiguate between the root part and its first child if
it's multipart.

[1]: https://golang.org/pkg/path/filepath/#Walk

Closes: https://github.com/emersion/go-message/issues/88