### PR TITLE
textproto: continue parsing on malformed header

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"strings"
 
@@ -88,7 +89,12 @@ func Read(r io.Reader) (*Entity, error) {
 	br := bufio.NewReader(r)
 	h, err := textproto.ReadHeader(br)
 	if err != nil {
-		return nil, err
+		e, newErr := New(Header{h}, br)
+		if newErr != nil {
+			return e, fmt.Errorf("%w: %v", err, newErr)
+		} else {
+			return e, err
+		}
 	}
 
 	return New(Header{h}, br)

--- a/textproto/header_test.go
+++ b/textproto/header_test.go
@@ -3,6 +3,7 @@ package textproto
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
 	"reflect"
 	"strings"
@@ -219,6 +220,27 @@ func TestInvalidHeader(t *testing.T) {
 	_, err := ReadHeader(r)
 	if err == nil {
 		t.Errorf("No error thrown")
+	}
+}
+
+const testmalformedHeader = "error\r\nKey1: Value\r\nerror\r\nKey2: Value\r\nerror\r\nKey3: Value\r\nerror\r\nKey4: Value\r\nerror\r\nKey5: Value\r\nerror\r\nKey6: Value\r\n"
+
+func TestMalformedHeader(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader(testmalformedHeader))
+	h, err := ReadHeader(r)
+	if err == nil {
+		t.Errorf("No error thrown")
+	}
+
+	for i := 1; i <= 5; i++ {
+		key := fmt.Sprintf("Key%d", i)
+		if h.Get(key) != "Value" {
+			t.Errorf("Key: %s should eqal Value", key)
+		}
+	}
+
+	if h.Get("Key6") == "Value" {
+		t.Errorf("Key6 should be skipped")
 	}
 }
 


### PR DESCRIPTION
Hi, I have added an Test which failed before. When there is a Line in the Header which doesnt have a ":", all Headers below that line was not parsed.

Read() now returns also an usable Entity even if was an error triggered. 

There are use-cases where a developer wants to Parse what is possible and use it, instead of failing the mail.
