### PR TITLE
Export Unknown{Charset,Encoding}Errors

### DIFF
--- a/charset.go
+++ b/charset.go
@@ -1,21 +1,27 @@
 package message
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"mime"
 	"strings"
 )
 
-type unknownCharsetError struct {
-	error
+type UnknownCharsetError struct {
+	e error
+}
+
+func (u UnknownCharsetError) Unwrap() error { return u.e }
+
+func (u UnknownCharsetError) Error() string {
+	return "unknown charset: " + u.e.Error()
 }
 
 // IsUnknownCharset returns a boolean indicating whether the error is known to
 // report that the charset advertised by the entity is unknown.
 func IsUnknownCharset(err error) bool {
-	_, ok := err.(unknownCharsetError)
-	return ok
+	return errors.As(err, new(UnknownCharsetError))
 }
 
 // CharsetReader, if non-nil, defines a function to generate charset-conversion

--- a/encoding.go
+++ b/encoding.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"mime/quotedprintable"
@@ -10,15 +11,20 @@ import (
 	"github.com/emersion/go-textwrapper"
 )
 
-type unknownEncodingError struct {
-	error
+type UnknownEncodingError struct {
+	e error
+}
+
+func (u UnknownEncodingError) Unwrap() error { return u.e }
+
+func (u UnknownEncodingError) Error() string {
+	return "encoding error: " + u.e.Error()
 }
 
 // IsUnknownEncoding returns a boolean indicating whether the error is known to
 // report that the encoding advertised by the entity is unknown.
 func IsUnknownEncoding(err error) bool {
-	_, ok := err.(unknownEncodingError)
-	return ok
+	return errors.As(err, new(UnknownEncodingError))
 }
 
 func encodingReader(enc string, r io.Reader) (io.Reader, error) {

--- a/entity.go
+++ b/entity.go
@@ -37,7 +37,7 @@ func New(header Header, body io.Reader) (*Entity, error) {
 	if !strings.HasPrefix(mediaType, "multipart/") {
 		enc := header.Get("Content-Transfer-Encoding")
 		if decoded, encErr := encodingReader(enc, body); encErr != nil {
-			err = unknownEncodingError{encErr}
+			err = UnknownEncodingError{encErr}
 		} else {
 			body = decoded
 		}
@@ -47,7 +47,7 @@ func New(header Header, body io.Reader) (*Entity, error) {
 	if strings.HasPrefix(mediaType, "text/") {
 		if ch, ok := mediaParams["charset"]; ok {
 			if converted, charsetErr := charsetReader(ch, body); charsetErr != nil {
-				err = unknownCharsetError{charsetErr}
+				err = UnknownCharsetError{charsetErr}
 			} else {
 				body = converted
 			}

--- a/entity_test.go
+++ b/entity_test.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"io/ioutil"
 	"strings"
@@ -222,6 +223,9 @@ func TestNew_unknownTransferEncoding(t *testing.T) {
 	}
 	if !IsUnknownEncoding(err) {
 		t.Fatal("New(unknown transfer encoding): expected an error that verifies IsUnknownEncoding")
+	}
+	if !errors.As(err, &UnknownEncodingError{}) {
+		t.Fatal("New(unknown transfer encoding): expected an error that verifies errors.As(err, &EncodingError{})")
 	}
 
 	if b, err := ioutil.ReadAll(e.Body); err != nil {


### PR DESCRIPTION
This allow us to use the go 1.13 error handling facility which is a bit cleaner
as it allows for a nested error lookup with

```
err = someTwoCallDeepGoMessageFunc()
	if errors.Is(err, message.UnknownEncodingError) {
		handleIt()
	}
```

Else it gets really clunky, as the caller has to unwrap the error to the exact error
returned by go-message and then using message.IsUnknownEncoding(err).

To keep backwards compatibility I've left the helpers in, so there should be no
breaking changes.