### PR TITLE
Ensure errors returned from fields.Text() verify IsUnknownCharset (fixes #107)

### DIFF
--- a/charset.go
+++ b/charset.go
@@ -49,7 +49,16 @@ func charsetReader(charset string, input io.Reader) (io.Reader, error) {
 // decodeHeader decodes an internationalized header field. If it fails, it
 // returns the input string and the error.
 func decodeHeader(s string) (string, error) {
-	wordDecoder := mime.WordDecoder{CharsetReader: charsetReader}
+	charsetReaderWrapper := func(charset string, input io.Reader) (io.Reader, error) {
+		r, err := charsetReader(charset, input)
+		if err != nil {
+			return input, UnknownCharsetError{err}
+		}
+
+		return r, nil
+	}
+
+	wordDecoder := mime.WordDecoder{CharsetReader: charsetReaderWrapper}
 	dec, err := wordDecoder.DecodeHeader(s)
 	if err != nil {
 		return s, err

--- a/header_test.go
+++ b/header_test.go
@@ -70,7 +70,7 @@ func TestKnownCharset(t *testing.T) {
 func TestUnknownCharset(t *testing.T) {
 	var h Header
 
-	h.Set("Subject", "=?ISO-8859-2?B?dSB1bmRlcnN0YW5kIHRoZSBleGFtcGxlLg==?=")
+	h.Set("Subject", "=?INVALIDCHARSET?B?dSB1bmRlcnN0YW5kIHRoZSBleGFtcGxlLg==?=")
 
 	fields := h.Fields()
 	if !fields.Next() {

--- a/header_test.go
+++ b/header_test.go
@@ -50,3 +50,38 @@ func TestEmptyContentType(t *testing.T) {
 		t.Errorf("Expected media type %q but got %q", mediaType, gotMediaType)
 	}
 }
+
+func TestKnownCharset(t *testing.T) {
+	var h Header
+
+	h.Set("Subject", "=?ISO-8859-1?B?SWYgeW91IGNhbiByZWFkIHRoaXMgeW8=?=")
+
+	fields := h.Fields()
+	if !fields.Next() {
+		t.Error("Expected to be able to advance to first header item")
+	}
+
+	_, err := fields.Text()
+	if err != nil {
+		t.Error("Expected no error when decoding header key of known charset, but got: ", err)
+	}
+}
+
+func TestUnknownCharset(t *testing.T) {
+	var h Header
+
+	h.Set("Subject", "=?ISO-8859-2?B?dSB1bmRlcnN0YW5kIHRoZSBleGFtcGxlLg==?=")
+
+	fields := h.Fields()
+	if !fields.Next() {
+		t.Error("Expected to be able to advance to first header item")
+	}
+
+	_, err := fields.Text()
+	if err == nil {
+		t.Error("Expected error decoding header key of unknown charset")
+	}
+	if !IsUnknownCharset(err) {
+		t.Error("Expected error to verify IsUnknownCharset")
+	}
+}


### PR DESCRIPTION
Related to issue https://github.com/emersion/go-message/issues/107; these tests should pass once we figure out what to do with #107 