### PR TITLE
fix: import cycle not allowed

### DIFF
--- a/textproto/textproto_test.go
+++ b/textproto/textproto_test.go
@@ -1,13 +1,12 @@
-package textproto_test
+package textproto
 
 import (
 	"fmt"
 
-	"github.com/emersion/go-message/textproto"
 )
 
 func ExampleHeader() {
-	var h textproto.Header
+	var h Header
 	h.Add("From", "<root@nsa.gov>")
 	h.Add("To", "<root@gchq.gov.uk>")
 	h.Set("Subject", "Tonight's dinner")


### PR DESCRIPTION
The build log looks like this: https://download.copr.fedorainfracloud.org/results/proletarius101/hydroxide/fedora-32-x86_64/01654615-golang-github-emersion-message-textproto/builder-live.log.gz

I'd say I'm not quite familiar with Go. And as I build the source code manually with the same command there is no error:

```shell
go test -buildmode pie -compiler gc -ldflags " -X github.com/emersion/go-message/textproto/version.commit=master -X github.com/emersion/go-message/textproto/version=0 -extldflags '-Wl,-z,relro -Wl,--as-needed  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld '"
```

I just made this commit by some guessing, and it works somehow.