### PR TITLE
Save the original raw body in the entity

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -2,7 +2,9 @@ package message
 
 import (
 	"bufio"
+	"bytes"
 	"io"
+	"io/ioutil"
 	"strings"
 
 	"github.com/emersion/go-message/textproto"
@@ -11,8 +13,9 @@ import (
 // An Entity is either a whole message or a one of the parts in the body of a
 // multipart entity.
 type Entity struct {
-	Header Header    // The entity's header.
-	Body   io.Reader // The decoded entity's body.
+	Header  Header    // The entity's header.
+	Body    io.Reader // The decoded entity's body.
+	RawBody []byte    // The raw entity's body.
 
 	mediaType   string
 	mediaParams map[string]string
@@ -25,7 +28,12 @@ type Entity struct {
 // error that verifies IsUnknownCharset, but also returns an Entity that can
 // be read.
 func New(header Header, body io.Reader) (*Entity, error) {
-	var err error
+	b, err := ioutil.ReadAll(body)
+	if err != nil {
+		return nil, err
+	}
+
+	body = bytes.NewReader(b)
 
 	mediaType, mediaParams, _ := header.ContentType()
 
@@ -57,6 +65,7 @@ func New(header Header, body io.Reader) (*Entity, error) {
 	return &Entity{
 		Header:      header,
 		Body:        body,
+		RawBody:     b,
 		mediaType:   mediaType,
 		mediaParams: mediaParams,
 	}, err


### PR DESCRIPTION
There's a good chance you won't like these changes due to unbounded allocations. I fully agree. This PR is more an invitation to discussion than a proposal of a concrete solution.

But it's important to have access to the original raw entity body in case it can't be decoded/read (example: messages that specify a transfer encoding yet have illegal base64/qp data). In that case, it's good to still have the original body there to do something with.

Can you think of any io.Reader magic that would facilitate this without the need for ioutil.ReadAll like I've done? I was thinking about wrapping the source reader in a TeeReader that writes the source data to a buffer, which then becomes RawBody. But that would mean you have to read all from Body before RawBody contains what you want, which isn't so great (you might not care about the decoded body at all and only ever want the raw body and be surprised that it's always empty if you never read from Body).

Any other smart ideas? 