### PR TITLE
mail: use type aliases for Address

### DIFF
--- a/mail/address.go
+++ b/mail/address.go
@@ -9,32 +9,15 @@ import (
 )
 
 // Address represents a single mail address.
-type Address mail.Address
-
-// String formats the address as a valid RFC 5322 address. If the address's name
-// contains non-ASCII characters the name will be rendered according to
-// RFC 2047.
-//
-// Don't use this function to set a message header field, instead use
-// Header.SetAddressList.
-func (a *Address) String() string {
-	return ((*mail.Address)(a)).String()
-}
+// The type alias ensures that a net/mail.Address can be used wherever an
+// Address is expected
+type Address = mail.Address
 
 func parseAddressList(s string) ([]*Address, error) {
 	parser := mail.AddressParser{
 		&mime.WordDecoder{message.CharsetReader},
 	}
-	list, err := parser.ParseList(s)
-	if err != nil {
-		return nil, err
-	}
-
-	addrs := make([]*Address, len(list))
-	for i, a := range list {
-		addrs[i] = (*Address)(a)
-	}
-	return addrs, nil
+	return parser.ParseList(s)
 }
 
 func formatAddressList(l []*Address) string {

--- a/mail/header_test.go
+++ b/mail/header_test.go
@@ -1,6 +1,7 @@
 package mail_test
 
 import (
+	netmail "net/mail"
 	"reflect"
 	"testing"
 	"time"
@@ -154,5 +155,24 @@ func TestHeader_SetMsgIDList(t *testing.T) {
 		if raw != test.raw {
 			t.Errorf("Failed to format In-Reply-To %q: Header.Get() = %q, want %q", test.msgIDs, raw, test.raw)
 		}
+	}
+}
+
+func TestHeader_CanUseNetMailAddress(t *testing.T) {
+	netfrom := []*netmail.Address{{"Mitsuha Miyamizu", "mitsuha.miyamizu@example.org"}}
+	mailfrom := []*mail.Address{{"Mitsuha Miyamizu", "mitsuha.miyamizu@example.org"}}
+
+	//sanity check that they types are identical
+	if !reflect.DeepEqual(netfrom, mailfrom) {
+		t.Error("[]*net/mail.Address differs from []*mail.Address")
+	}
+
+	//roundtrip
+	var h mail.Header
+	h.SetAddressList("From", netfrom)
+	if got, err := h.AddressList("From"); err != nil {
+		t.Error("Expected no error while parsing header address list, got:", err)
+	} else if !reflect.DeepEqual(got, netfrom) {
+		t.Errorf("Expected header address list to be %v, but got %v", netfrom, got)
 	}
 }


### PR DESCRIPTION
using a type alias allows users to provide a net/mail.Address wherever an
Address is expected, avoiding the conversion necessary until now.

Fixes https://github.com/emersion/go-message/issues/11