### PR TITLE
Export ParseAddressList and add ParseAddress for symetry

### DIFF
--- a/mail/address.go
+++ b/mail/address.go
@@ -13,17 +13,30 @@ import (
 // Address is expected
 type Address = mail.Address
 
-func parseAddressList(s string) ([]*Address, error) {
-	parser := mail.AddressParser{
-		&mime.WordDecoder{message.CharsetReader},
-	}
-	return parser.ParseList(s)
-}
-
 func formatAddressList(l []*Address) string {
 	formatted := make([]string, len(l))
 	for i, a := range l {
 		formatted[i] = a.String()
 	}
 	return strings.Join(formatted, ", ")
+}
+
+// ParseAddress parses a single RFC 5322 address, e.g. "Barry Gibbs <bg@example.com>"
+// Use this function only if you parse from a string, if you have a Header use
+// Header.AddressList instead
+func ParseAddress(address string) (*Address, error) {
+	parser := mail.AddressParser{
+		&mime.WordDecoder{message.CharsetReader},
+	}
+	return parser.Parse(address)
+}
+
+// ParseAddressList parses the given string as a list of addresses.
+// Use this function only if you parse from a string, if you have a Header use
+// Header.AddressList instead
+func ParseAddressList(list string) ([]*Address, error) {
+	parser := mail.AddressParser{
+		&mime.WordDecoder{message.CharsetReader},
+	}
+	return parser.ParseList(list)
 }

--- a/mail/address_test.go
+++ b/mail/address_test.go
@@ -1,0 +1,30 @@
+package mail_test
+
+import (
+	"net/mail"
+	"reflect"
+	"testing"
+)
+
+func TestParseAddressList(t *testing.T) {
+	want := []*mail.Address{{"Mitsuha Miyamizu", "mitsuha.miyamizu@example.org"},
+		{"Han Solo", "hanibunny@example.org"},
+	}
+	input := "Mitsuha Miyamizu <mitsuha.miyamizu@example.org>,Han Solo <hanibunny@example.org>"
+	if got, err := mail.ParseAddressList(input); err != nil {
+		t.Error("Expected no error while parsing address list got:", err)
+	} else if !reflect.DeepEqual(got, want) {
+		t.Errorf("Expected address list to be %v, but got %v", want, got)
+	}
+}
+
+func TestParseAddress(t *testing.T) {
+	want := &mail.Address{"Mitsuha Miyamizu", "mitsuha.miyamizu@example.org"}
+	input := "Mitsuha Miyamizu <mitsuha.miyamizu@example.org>"
+
+	if got, err := mail.ParseAddress(input); err != nil {
+		t.Error("Expected no error while parsing address got:", err)
+	} else if !reflect.DeepEqual(got, want) {
+		t.Errorf("Expected address to be %v, but got %v", want, got)
+	}
+}

--- a/mail/header.go
+++ b/mail/header.go
@@ -232,7 +232,7 @@ func (h *Header) AddressList(key string) ([]*Address, error) {
 	if v == "" {
 		return nil, nil
 	}
-	return parseAddressList(v)
+	return ParseAddressList(v)
 }
 
 // SetAddressList formats the named header field to the provided list of


### PR DESCRIPTION
This exposes essentially the same API as net/mail for parsing strings.
Doc strings should make it obvious that this should not be used on a header.