### PR TITLE
expand Has check to also verify the key is there

### DIFF
--- a/textproto/header.go
+++ b/textproto/header.go
@@ -174,7 +174,15 @@ func (h *Header) Del(k string) {
 // Has checks whether the header has a field with the specified key.
 func (h *Header) Has(k string) bool {
 	_, ok := h.m[textproto.CanonicalMIMEHeaderKey(k)]
-	return ok
+	if ok {
+		// Also check if key exists
+		for i := 0; i < len(h.l); i++ {
+			if h.l[i].k == k {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // Copy creates an independent copy of the header.


### PR DESCRIPTION
This fixes a problem when calling `CreateSingleInlineWriter` twice in a row. The `Has` in `initInlineContentTransferEncoding` is `true` the second time, but there's no key so it won't appear in the header.

I believe this corrects the behavior of `Has`.