### PR TITLE
textproto: introduce Header.Values

### DIFF
--- a/textproto/header.go
+++ b/textproto/header.go
@@ -141,13 +141,29 @@ func (h *Header) Get(k string) string {
 // The returned slice should not be modified and becomes invalid when the
 // header is updated.
 //
-// Error is returned if header contains incorrect characters (RFC 6532)
+// Error is returned if header contains incorrect characters (RFC 6532).
 func (h *Header) Raw(k string) ([]byte, error) {
 	fields := h.m[textproto.CanonicalMIMEHeaderKey(k)]
 	if len(fields) == 0 {
 		return nil, nil
 	}
 	return fields[len(fields)-1].raw()
+}
+
+// Values returns all values associated with the given key.
+//
+// The returned slice should not be modified and becomes invalid when the
+// header is updated.
+func (h *Header) Values(k string) []string {
+	fields := h.m[textproto.CanonicalMIMEHeaderKey(k)]
+	if len(fields) == 0 {
+		return nil
+	}
+	l := make([]string, len(fields))
+	for i, field := range fields {
+		l[len(fields)-i-1] = field.v
+	}
+	return l
 }
 
 // Set sets the header fields associated with key to the single field value.

--- a/textproto/header_test.go
+++ b/textproto/header_test.go
@@ -80,6 +80,14 @@ func TestHeader(t *testing.T) {
 	if h.FieldsByKey("X-I-Dont-Exist").Next() {
 		t.Errorf("FieldsByKey(non-existing).Next() returned true, want false")
 	}
+
+	want = []string{
+		"from example.com by example.org",
+		"from localhost by example.com",
+	}
+	if l := h.Values("Received"); !reflect.DeepEqual(l, want) {
+		t.Errorf("Values(\"Received\") reported incorrect values: got \n%#v\n but want \n%#v", l, want)
+	}
 }
 
 func TestHeader_Set(t *testing.T) {


### PR DESCRIPTION
Same as textproto.MIMEHeader.Values in the stdlib [1].

The doc comment says the returned slice is read-only, but we actually do
a copy. This is so we don't put ourselves into a corner and can change
how the function works internally in the future.

[1]: https://golang.org/pkg/net/textproto/#MIMEHeader.Values