### PR TITLE
operate on a copy of the header for write methods

### DIFF
--- a/mail/writer.go
+++ b/mail/writer.go
@@ -41,6 +41,7 @@ type Writer struct {
 
 // CreateWriter writes a mail header to w and creates a new Writer.
 func CreateWriter(w io.Writer, header Header) (*Writer, error) {
+	header = header.Copy() // don't modify the caller's view
 	header.Set("Content-Type", "multipart/mixed")
 
 	mw, err := message.CreateWriter(w, header.Header)
@@ -55,6 +56,7 @@ func CreateWriter(w io.Writer, header Header) (*Writer, error) {
 // inline part, allowing to represent the same text in different formats.
 // Attachments cannot be included.
 func CreateInlineWriter(w io.Writer, header Header) (*InlineWriter, error) {
+	header = header.Copy() // don't modify the caller's view
 	header.Set("Content-Type", "multipart/alternative")
 
 	mw, err := message.CreateWriter(w, header.Header)
@@ -70,6 +72,7 @@ func CreateInlineWriter(w io.Writer, header Header) (*InlineWriter, error) {
 // io.WriteCloser. Only one single inline part should be written, use
 // CreateWriter if you want multiple parts.
 func CreateSingleInlineWriter(w io.Writer, header Header) (io.WriteCloser, error) {
+	header = header.Copy() // don't modify the caller's view
 	initInlineContentTransferEncoding(&header.Header)
 	return message.CreateWriter(w, header.Header)
 }
@@ -92,6 +95,7 @@ func (w *Writer) CreateInline() (*InlineWriter, error) {
 // one single text part should be written, use CreateInline if you want multiple
 // text parts.
 func (w *Writer) CreateSingleInline(h InlineHeader) (io.WriteCloser, error) {
+	h = InlineHeader{h.Header.Copy()} // don't modify the caller's view
 	initInlineHeader(&h)
 	return w.mw.CreatePart(h.Header)
 }
@@ -99,6 +103,7 @@ func (w *Writer) CreateSingleInline(h InlineHeader) (io.WriteCloser, error) {
 // CreateAttachment creates a new attachment with the provided header. The body
 // of the part should be written to the returned io.WriteCloser.
 func (w *Writer) CreateAttachment(h AttachmentHeader) (io.WriteCloser, error) {
+	h = AttachmentHeader{h.Header.Copy()} // don't modify the caller's view
 	initAttachmentHeader(&h)
 	return w.mw.CreatePart(h.Header)
 }
@@ -116,6 +121,7 @@ type InlineWriter struct {
 // CreatePart creates a new text part with the provided header. The body of the
 // part should be written to the returned io.WriteCloser.
 func (w *InlineWriter) CreatePart(h InlineHeader) (io.WriteCloser, error) {
+	h = InlineHeader{h.Header.Copy()} // don't modify the caller's view
 	initInlineHeader(&h)
 	return w.mw.CreatePart(h.Header)
 }

--- a/writer.go
+++ b/writer.go
@@ -70,6 +70,9 @@ func createWriter(w io.Writer, header *Header) (*Writer, error) {
 // The charset needs to be utf-8 or us-ascii.
 func CreateWriter(w io.Writer, header Header) (*Writer, error) {
 
+	// ensure that modifications are invisible to the caller
+	header = header.Copy()
+
 	// If the message uses MIME, it has to include MIME-Version
 	header.Set("MIME-Version", "1.0")
 
@@ -113,6 +116,9 @@ func (w *Writer) CreatePart(header Header) (*Writer, error) {
 	// cw -> ww -> pw -> w.mw -> w.w
 
 	ww := &struct{ io.Writer }{nil}
+
+	// ensure that modifications are invisible to the caller
+	header = header.Copy()
 	cw, err := createWriter(ww, &header)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
If callers pass the same header to CreateSingleInlineWriter or similar methods,
the header gets modified in place, which means that the header of the caller
and the header of go-message go out of sync and subsequent operations on the
same header fail.
Operate on a copy in all paths that modify the header to avoid this issue.