### PR TITLE
Wrap quoted-printable long lines with soft line breaks before parsing

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -31,7 +31,7 @@ func encodingReader(enc string, r io.Reader) (io.Reader, error) {
 	var dec io.Reader
 	switch strings.ToLower(enc) {
 	case "quoted-printable":
-		dec = quotedprintable.NewReader(r)
+		dec = newQuotedPrintableLongLinesReader(r)
 	case "base64":
 		dec = base64.NewDecoder(base64.StdEncoding, r)
 	case "7bit", "8bit", "binary", "":

--- a/quotedprintable.go
+++ b/quotedprintable.go
@@ -1,0 +1,67 @@
+package message
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"mime/quotedprintable"
+)
+
+const (
+	// defaultBufSize defines the buffer size used by `mime/quotedprintable`.
+	defaultBufSize = 4096
+
+	// maxQuotedPrintableLineLength defines the longest line accepted. Longer
+	// lines are splitted by inserting soft breakes.
+	// By RFC is allowed line with 76 characters long only. Some messages in
+	// the wild do not respect this rule. `mime/quotedprintable` can support
+	// up to bufio buffer, which is 4096 bytes. Longer lines than what RFC
+	// defines but shorter than bufio buffer are kept without modification
+	// to not modify message when not neccessary.
+	// Note that soft brake has to continue with line ending, i.e., `Read`
+	// operation cannot fill the whole quotedprintable buffer with the line
+	// without line ending. That is reported as error too. That's why this
+	// lenght is two bytes (to include \r\n) shorter then the buffer.
+	maxQuotedPrintableLineLength = defaultBufSize - 3
+)
+
+type quotedPrintableLongLinesReader struct {
+	r   *bufio.Reader
+	buf bytes.Buffer
+}
+
+func newQuotedPrintableLongLinesReader(r io.Reader) io.Reader {
+	return quotedprintable.NewReader(&quotedPrintableLongLinesReader{
+		r: bufio.NewReaderSize(r, maxQuotedPrintableLineLength),
+	})
+}
+
+func (l *quotedPrintableLongLinesReader) Read(p []byte) (int, error) {
+	if l.buf.Len() == 0 {
+		line, err := l.r.ReadSlice('\n')
+		// ErrBufferFull is returned once the line is not complete.
+		if len(line) == 0 && err != nil && err != bufio.ErrBufferFull {
+			return 0, err
+		}
+
+		if err != bufio.ErrBufferFull {
+			l.buf.Write(line)
+		} else {
+			length := len(line)
+			suffix := 0
+			if line[length-1] == byte('=') {
+				suffix = 1
+			} else if line[length-2] == byte('=') {
+				suffix = 2
+			}
+
+			l.buf.Write(line[:length-suffix])
+			l.buf.Write([]byte("=\r\n"))
+			if suffix > 0 {
+				l.buf.Write(line[length-suffix:])
+			}
+		}
+	}
+
+	return l.buf.Read(p)
+}

--- a/quotedprintable_test.go
+++ b/quotedprintable_test.go
@@ -1,0 +1,110 @@
+package message
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+func TestQuotedPrintableLongLines(t *testing.T) {
+	long := func(ending string) string {
+		return strings.Repeat(".", maxQuotedPrintableLineLength-3) + ending
+	}
+
+	tests := []struct {
+		input, output string
+	}{
+		{
+			"abc",
+			"abc",
+		},
+		{
+			long("abcdefghijkloooong"),
+			long("abcdefghijkloooong"),
+		},
+		// Original soft end of line around the wrap position.
+		{
+			long("=\r\nabcd"),
+			long("abcd"),
+		},
+		{
+			long("a=\r\nbcd"),
+			long("abcd"),
+		},
+		{
+			long("ab=\r\ncd"),
+			long("abcd"),
+		},
+		{
+			long("abc=\r\nd"),
+			long("abcd"),
+		},
+		{
+			long("abcd=\r\n"),
+			long("abcd"),
+		},
+		// Encoded = around the wrap position.
+		{
+			long("=3Dabcd"),
+			long("=abcd"),
+		},
+		{
+			long("a=3Dbcd"),
+			long("a=bcd"),
+		},
+		{
+			long("ab=3Dcd"),
+			long("ab=cd"),
+		},
+		{
+			long("abc=3Dd"),
+			long("abc=d"),
+		},
+		{
+			long("abcd=3D"),
+			long("abcd="),
+		},
+		// Encoded é around the wrap position.
+		{
+			long("=C3=A9abcd"),
+			long("éabcd"),
+		},
+		{
+			long("a=C3=A9bcd"),
+			long("aébcd"),
+		},
+		{
+			long("ab=C3=A9cd"),
+			long("abécd"),
+		},
+		{
+			long("abc=C3=A9d"),
+			long("abcéd"),
+		},
+		{
+			long("abcd=C3=A9"),
+			long("abcdé"),
+		},
+		// Very long line with many wraps.
+		{
+			long(long(long(long(long("abc"))))),
+			long(long(long(long(long("abc"))))),
+		},
+	}
+	for idx, tc := range tests {
+		tc := tc
+		t.Run(fmt.Sprintf("%v", idx), func(t *testing.T) {
+			inputReader := bytes.NewReader([]byte(tc.input + "\r\n"))
+			outputReader := newQuotedPrintableLongLinesReader(inputReader)
+			output, err := ioutil.ReadAll(outputReader)
+			if err != nil {
+				t.Error("Expected no error, but got:", err)
+			}
+			if string(output) != tc.output+"\r\n" {
+				t.Errorf("Expected %v but got %v", tc.output, string(output))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Yep, such messages exist, even created recently. 😞 