### PR TITLE
Respect existing `Mime-Version:` header

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -74,7 +74,9 @@ func CreateWriter(w io.Writer, header Header) (*Writer, error) {
 	header = header.Copy()
 
 	// If the message uses MIME, it has to include MIME-Version
-	header.Set("MIME-Version", "1.0")
+	if !header.Has("Mime-Version") {
+		header.Set("MIME-Version", "1.0")
+	}
 
 	ww, err := createWriter(w, &header)
 	if err != nil {


### PR DESCRIPTION
Function `CreateWriter()` always set/reset header `Mime-Version: 1.0`. it was introduced by PR #90.
https://github.com/emersion/go-message/blob/master/writer.go#L77

In my case, i read message from `os.Stdin`, then write message to disk with `WriteTo()` (and it calls `CreateWriter()`). As you can imagine, the message already contains `Mime-Version:` header, for example:

```
Mime-Version: 1.0 (Mac OS X Mail 13.4 \(3608.120.23.2.4\))
```

go-message should respects existing header(s), only add if it's missing.