### PR TITLE
Move header size restriction from textproto to message

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -2,7 +2,9 @@ package message
 
 import (
 	"bufio"
+	"errors"
 	"io"
+	"math"
 	"strings"
 
 	"github.com/emersion/go-message/textproto"
@@ -77,6 +79,28 @@ func NewMultipart(header Header, parts []*Entity) (*Entity, error) {
 	return New(header, r)
 }
 
+const maxHeaderBytes = 1 << 20 // 1 MB
+
+var errHeaderTooBig = errors.New("message: header exceeds maximum size")
+
+// limitedReader is the same as io.LimitedReader, but returns a custom error.
+type limitedReader struct {
+	R io.Reader
+	N int64
+}
+
+func (lr *limitedReader) Read(p []byte) (int, error) {
+	if lr.N <= 0 {
+		return 0, errHeaderTooBig
+	}
+	if int64(len(p)) > lr.N {
+		p = p[0:lr.N]
+	}
+	n, err := lr.R.Read(p)
+	lr.N -= int64(n)
+	return n, err
+}
+
 // Read reads a message from r. The message's encoding and charset are
 // automatically decoded to raw UTF-8. Note that this function only reads the
 // message header.
@@ -85,11 +109,15 @@ func NewMultipart(header Header, parts []*Entity) (*Entity, error) {
 // error that verifies IsUnknownCharset or IsUnknownEncoding, but also returns
 // an Entity that can be read.
 func Read(r io.Reader) (*Entity, error) {
-	br := bufio.NewReader(r)
+	lr := &limitedReader{R: r, N: maxHeaderBytes}
+	br := bufio.NewReader(lr)
+
 	h, err := textproto.ReadHeader(br)
 	if err != nil {
 		return nil, err
 	}
+
+	lr.N = math.MaxInt64
 
 	return New(Header{h}, br)
 }

--- a/entity_test.go
+++ b/entity_test.go
@@ -152,6 +152,16 @@ func TestRead_single(t *testing.T) {
 	}
 }
 
+func TestRead_tooBig(t *testing.T) {
+	raw := "Subject: " + strings.Repeat("A", 4096 * 1024) + "\r\n" +
+		"\r\n" +
+		"This header is too big.\r\n"
+	_, err := Read(strings.NewReader(raw))
+	if err != errHeaderTooBig {
+		t.Fatalf("Read() = %q, want %q", err, errHeaderTooBig)
+	}
+}
+
 func TestEntity_WriteTo_decode(t *testing.T) {
 	e := testMakeEntity()
 

--- a/textproto/header_test.go
+++ b/textproto/header_test.go
@@ -230,32 +230,6 @@ func TestInvalidHeader(t *testing.T) {
 	}
 }
 
-func TestReadHeader_TooBig(t *testing.T) {
-	testHeader := "Received: from example.com by example.org\r\n" +
-		"Received: from localhost by example.com\r\n" +
-		"To: Taki Tachibana <taki.tachibana@example.org> " + strings.Repeat("A", 4000) + "\r\n" +
-		"From: Mitsuha Miyamizu <mitsuha.miyamizu@example.com>\r\n\r\n"
-	_, err := ReadHeader(bufio.NewReader(strings.NewReader(testHeader)))
-	if err == nil {
-		t.Fatalf("ReadHeader() succeeded")
-	}
-	if _, ok := err.(TooBigError); !ok {
-		t.Fatalf("Not TooBigError returned: %T", err)
-	}
-
-	testHeader = "Received: from example.com by example.org\r\n" +
-		"Received: from localhost by example.com\r\n" +
-		"To: Taki Tachibana <taki.tachibana@example.org>\r\n" +
-		strings.Repeat("From: Mitsuha Miyamizu <mitsuha.miyamizu@example.com>\r\n", 1001) + "\r\n"
-	_, err = ReadHeader(bufio.NewReader(strings.NewReader(testHeader)))
-	if err == nil {
-		t.Fatalf("ReadHeader() succeeded")
-	}
-	if _, ok := err.(TooBigError); !ok {
-		t.Fatalf("Not TooBigError returned: %T", err)
-	}
-}
-
 const testHeaderWithoutBody = "Received: from example.com by example.org\r\n" +
 	"Received: from localhost by example.com\r\n" +
 	"To: Taki Tachibana <taki.tachibana@example.org>\r\n" +


### PR DESCRIPTION
It's not really useful to individually check the line length or the
number of fields, what we really care about is the total header size.
This is also what net/http checks for.

Remove size checks from textproto, since callers can implement them. Use
a variant of io.LimitedReader in message instead.