### PR TITLE
mail: use stdlib instead of external dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,6 @@ module github.com/emersion/go-message
 go 1.13
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emersion/go-textwrapper v0.0.0-20200911093747-65d896831594
-	github.com/martinlindhe/base36 v1.1.0
-	github.com/stretchr/testify v1.3.0 // indirect
 	golang.org/x/text v0.3.5-0.20201125200606-c27b9fd57aec
 )

--- a/go.sum
+++ b/go.sum
@@ -1,16 +1,5 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emersion/go-textwrapper v0.0.0-20200911093747-65d896831594 h1:IbFBtwoTQyw0fIM5xv1HF+Y+3ZijDR839WMulgxCcUY=
 github.com/emersion/go-textwrapper v0.0.0-20200911093747-65d896831594/go.mod h1:aqO8z8wPrjkscevZJFVE1wXJrLpC5LtJG7fqLOsPb2U=
-github.com/martinlindhe/base36 v1.1.0 h1:cIwvvwYse/0+1CkUPYH5ZvVIYG3JrILmQEIbLuar02Y=
-github.com/martinlindhe/base36 v1.1.0/go.mod h1:+AtEs8xrBpCeYgSLoY/aJ6Wf37jtBuR0s35750M27+8=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/text v0.3.5-0.20201125200606-c27b9fd57aec h1:A1qYjneJuzBZZ2gIB8rd6zrfq6l7SoEMJ8EsSilNK/U=
 golang.org/x/text v0.3.5-0.20201125200606-c27b9fd57aec/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
I'm not sure if there is a specific reason for doing it as it currently is? Anyhow, this pull request removes this otherwise unused external dependency and use strconv to base36 encode. This has the side effect of reducing allocations as well as improving execution times.  Output should be comparable;

```
Old: C9EDU8EPQBGY.1OPA7WEUKTFIY@hostname
New: C9EDU7U5NQNZ.1T2B0PIFP4V88@hostname
Old: C9EE4CRAIMU9.35K02SYKO9VWW@hostname
New: C9EE4C6I3XNX.2V6K31R712RT@hostname
```

And benchmark diff using `benchstat` when calling the `GenerateMessageID` function;
```
name                      old time/op    new time/op    delta
Header_GenerateMessageID    8.71µs ± 5%    6.59µs ±10%  -24.29%  (p=0.000 n=10+10)

name                      old alloc/op   new alloc/op   delta
Header_GenerateMessageID      606B ± 0%      275B ± 0%  -54.58%  (p=0.000 n=10+10)

name                      old allocs/op  new allocs/op  delta
Header_GenerateMessageID      45.0 ± 0%      13.0 ± 0%  -71.11%  (p=0.000 n=10+10)
```