### PR TITLE
Add function to set Message-ID hostname manually

### DIFF
--- a/mail/header.go
+++ b/mail/header.go
@@ -304,10 +304,25 @@ func (h *Header) MsgIDList(key string) ([]string, error) {
 	return l, nil
 }
 
-// GenerateMessageID generates an RFC 2822-compliant Message-Id based on the
-// informational draft "Recommendations for generating Message IDs", for lack
-// of a better authoritative source.
+// GenerateMessageID wraps GenerateMessageIDWithHostname and therefore uses the
+// hostname of the local machine. This is done to not break existing software.
+// Wherever possible better use GenerateMessageIDWithHostname, because the local
+// hostname of a machine tends to not be unique nor a FQDN which especially
+// brings problems with spam filters.
 func (h *Header) GenerateMessageID() error {
+	var err error
+	hostname, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+	return h.GenerateMessageIDWithHostname(hostname)
+}
+
+// GenerateMessageIDWithHostname generates an RFC 2822-compliant Message-Id
+// based on the informational draft "Recommendations for generating Message
+// IDs", it takes an hostname as argument, so that software using this library
+// could use a hostname they know to be unique
+func (h *Header) GenerateMessageIDWithHostname(hostname string) error {
 	now := uint64(time.Now().UnixNano())
 
 	nonceByte := make([]byte, 8)
@@ -315,11 +330,6 @@ func (h *Header) GenerateMessageID() error {
 		return err
 	}
 	nonce := binary.BigEndian.Uint64(nonceByte)
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		return err
-	}
 
 	msgID := fmt.Sprintf("%s.%s@%s", base36(now), base36(nonce), hostname)
 	h.SetMessageID(msgID)


### PR DESCRIPTION
Usually the hostname of the local machine tends to be not unique nor a
FQDN. This brings multiple problems with it when sending messages using
such Message-ID.

First of all this makes go-message more compliant to RFC5322 [1] because
it recommends to use a FQDN on the right handed side of the @ in the
Message-ID. Second this also improves the situation with spam filters,
because some of them (for example rspamd) give a bad score for messages
without a FQDN in the Message-ID.

[1] https://www.rfc-editor.org/rfc/rfc5322.html#section-3.6.4