### PR TITLE
Introduce a new entity func ReadWithOptions. 

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -126,6 +126,10 @@ func (o ReadOptions) withDefaults() *ReadOptions {
 // returns an error that verifies IsUnknownCharset or IsUnknownEncoding, but
 // also returns an Entity that can be read.
 func ReadWithOptions(r io.Reader, opts *ReadOptions) (*Entity, error) {
+
+	if opts == nil {
+		opts = &ReadOptions{}
+	}
 	opts = opts.withDefaults()
 
 	lr := &limitedReader{R: r, N: opts.MaxHeaderBytes}

--- a/entity_test.go
+++ b/entity_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
+	"math"
 	"reflect"
 	"strings"
 	"testing"
@@ -159,6 +160,16 @@ func TestRead_tooBig(t *testing.T) {
 	_, err := Read(strings.NewReader(raw))
 	if err != errHeaderTooBig {
 		t.Fatalf("Read() = %q, want %q", err, errHeaderTooBig)
+	}
+}
+
+func TestReadWithOptions_canSetMaxHeaderBytes(t *testing.T) {
+	raw := "Subject: " + strings.Repeat("A", 4096*1024) + "\r\n" +
+		"\r\n" +
+		"This header is very big, but we should allow it via options.\r\n"
+	_, err := ReadWithOptions(strings.NewReader(raw), ReadOptions{MaxHeaderBytes: math.MaxInt64})
+	if err != nil {
+		t.Fatalf("Read() = %q, want nil", err)
 	}
 }
 

--- a/entity_test.go
+++ b/entity_test.go
@@ -230,6 +230,16 @@ func TestReadWithOptions(t *testing.T) {
 	}
 }
 
+func TestReadWithOptions_nilDefault(t *testing.T) {
+	raw := "Subject: Something\r\n"
+	var opts *ReadOptions
+	opts = nil
+	_, err := ReadWithOptions(strings.NewReader(raw), opts)
+	if err != nil {
+		t.Fatalf("ReadWithOptions() = %v", err)
+	}
+}
+
 func TestEntity_WriteTo_decode(t *testing.T) {
 	e := testMakeEntity()
 


### PR DESCRIPTION
This provides a way to customise the behaviour of Read, starting with the max permissible size headers can be. Resolves #149 