### PR TITLE
header: prevent setting empty address list headers

### DIFF
--- a/mail/header.go
+++ b/mail/header.go
@@ -243,7 +243,11 @@ func (h *Header) AddressList(key string) ([]*Address, error) {
 //
 // This can be used on From, Sender, Reply-To, To, Cc and Bcc header fields.
 func (h *Header) SetAddressList(key string, addrs []*Address) {
-	h.Set(key, formatAddressList(addrs))
+	if len(addrs) > 0 {
+		h.Set(key, formatAddressList(addrs))
+	} else {
+		h.Del(key)
+	}
 }
 
 // Date parses the Date header field.


### PR DESCRIPTION
Prevent setting empty address list headers (to, from, cc, bcc). RFCC
5322 states that destination address list headers contain the field name
and one or more addresses, implying that empty headers are not allowed.