### PR TITLE
mail: decode headers when using AddressList

### DIFF
--- a/mail/header.go
+++ b/mail/header.go
@@ -231,7 +231,10 @@ func HeaderFromMap(m map[string][]string) Header {
 //
 // This can be used on From, Sender, Reply-To, To, Cc and Bcc header fields.
 func (h *Header) AddressList(key string) ([]*Address, error) {
-	v := h.Get(key)
+	v, err := h.Text(key)
+	if err != nil {
+		v = h.Get(key)
+	}
 	if v == "" {
 		return nil, nil
 	}

--- a/mail/header_test.go
+++ b/mail/header_test.go
@@ -215,3 +215,34 @@ func TestHeader_EmptyAddressList(t *testing.T) {
 	}
 
 }
+
+func TestHeader_EncodedAddressList(t *testing.T) {
+	tests := []struct {
+		list []*mail.Address
+		want []*mail.Address
+	}{
+		{
+			[]*mail.Address{{"Mitsuha Miyamizu", "mitsuha.miyamizu@example.org"}},
+			[]*mail.Address{{"Mitsuha Miyamizu", "mitsuha.miyamizu@example.org"}},
+		},
+		{
+			[]*mail.Address{{"=?utf-8?Q?Mitsuha?= Miyamizu", "mitsuha.miyamizu@example.org"}, {"Mitsuha Miyamizu", "mitsuha.miyamizu@example.org"}},
+			[]*mail.Address{{"Mitsuha Miyamizu", "mitsuha.miyamizu@example.org"}, {"Mitsuha Miyamizu", "mitsuha.miyamizu@example.org"}},
+		},
+		{
+			[]*mail.Address{{"=?wrongencoding?Q?Mitsuha?= Miyamizu", "mitsuha.miyamizu@example.org"}},
+			[]*mail.Address{{"=?wrongencoding?Q?Mitsuha?= Miyamizu", "mitsuha.miyamizu@example.org"}},
+		},
+	}
+
+	for _, test := range tests {
+		var h mail.Header
+		h.SetAddressList("From", test.list)
+		if got, err := h.AddressList("From"); err != nil {
+			t.Error("Expected no error while parsing header address list, got:", err)
+		} else if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("Expected header address list to be %v, but got %v", test.want, got)
+		}
+	}
+
+}


### PR DESCRIPTION
Decode address names when calling header.AdressList by first trying header.Text instead of header.Get.

Encoded names will now be correctly decoded before sent to the addresslist parser, i.e. "=?utf-8?Q?Mitsuha?= Miyamizu" will be shown as "Mitsuha Miyamizu".