### PR TITLE
Detect missing boundary EOF

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/emersion/go-message
+module github.com/hudon/go-message
 
 go 1.14
 


### PR DESCRIPTION
fix #129 

This fix looks for a specific error message from `textproto` which indicates a missing boundary EOF. It's not a super stable solution because `textproto` may change their error messages, but in the worst case, this fix will fallback on old behavior, so it doesn't break existing behavior.

A more stable solution could be to explicitly detect the missing boundary EOF ourselves.