### PR TITLE
Add extended charset support for writing

### DIFF
--- a/entity_test.go
+++ b/entity_test.go
@@ -411,6 +411,7 @@ func TestEntity_WriteTo_convert_charset_transfer(t *testing.T) {
 
 	expected := "Mime-Version: 1.0\r\n" +
 		"Content-Type: text/plain; charset=utf-8\r\n" +
+		"Content-Transfer-Encoding: quoted-printable\r\n" +
 		"\r\n" +
 		"quoted =C3=A9 =E2=82=AC"
 

--- a/writer.go
+++ b/writer.go
@@ -50,16 +50,14 @@ func createWriter(w io.Writer, header *Header) (*Writer, error) {
 		if err != nil {
 			return nil, err
 		}
-		ww.w = wc
-		ww.c = wc
-	}
 
-	switch strings.ToLower(mediaParams["charset"]) {
-	case "", "us-ascii", "utf-8":
-		// This is OK
-	default:
-		// Anything else is invalid
-		return nil, fmt.Errorf("unhandled charset %q", mediaParams["charset"])
+		converted, err := charsetWriter(strings.ToLower(mediaParams["charset"]), wc)
+		if err != nil {
+			return nil, fmt.Errorf("unhandled charset %q", mediaParams["charset"])
+		}
+
+		ww.w = converted
+		ww.c = wc
 	}
 
 	return ww, nil


### PR DESCRIPTION
Adds a `CharsetWriter` func to mirror `CharsetReader`, but for writing. The main use case for this (that prompted me to make this PR) is the ability to use `Entity`'s `WriteTo` func for all messages that the library already supports for reading.

The existing write behavior for `utf-8` and `us-ascii` is persisted; this primarily just adds support for other charsets. 