### PR TITLE
charset: support x-UTF_8J

### DIFF
--- a/charset/charset.go
+++ b/charset/charset.go
@@ -12,6 +12,7 @@ import (
 	"github.com/emersion/go-message"
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/charmap"
+	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/encoding/htmlindex"
 	"golang.org/x/text/encoding/ianaindex"
 )
@@ -24,6 +25,7 @@ import (
 // https://www.iana.org/assignments/character-sets/character-sets.xhtml
 var charsets = map[string]encoding.Encoding{
 	"ansi_x3.110-1983": charmap.ISO8859_1, // see RFC 1345 page 62, mostly superset of ISO 8859-1
+	"x-utf_8j": unicode.UTF8, // alias for UTF-8, see https://icu4c-demos.unicode.org/icu-bin/convexp?s=ALL
 }
 
 func init() {


### PR DESCRIPTION
I just received a message with an attachment with the x-UTF_8J charset and was unable to open it with [aerc](https://sr.ht/~rjarry/aerc/). Rather than creating a workaround in aerc, it seems to make more sense to make it a supported charset.
