### PR TITLE
Support iso-8859-1 encoding

### DIFF
--- a/encoding_test.go
+++ b/encoding_test.go
@@ -2,12 +2,33 @@ package message
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/encoding/charmap"
+	"golang.org/x/text/transform"
 )
+
+func TestUtil(t *testing.T) {
+	vietnameseText := "Hôm nay trời đẹp quá!"
+	var encodedBuffer bytes.Buffer
+	encoder := charmap.Windows1258.NewEncoder()
+	writer := transform.NewWriter(&encodedBuffer, encoder)
+	if _, err := writer.Write([]byte(vietnameseText)); err != nil {
+		fmt.Println("Error encoding:", err)
+		return
+	}
+	if err := writer.Close(); err != nil {
+		fmt.Println("Error closing writer:", err)
+		return
+	}
+	encodedBytes := encodedBuffer.Bytes()
+	fmt.Println("Encoded bytes:", encodedBytes)
+	fmt.Println("Encoded string:", fmt.Sprintf("% x", encodedBytes))
+}
 
 var testEncodings = []struct {
 	enc     string
@@ -30,6 +51,16 @@ var testEncodings = []struct {
 		decoded: "hi there",
 	},
 	{
+		enc:     "utf8",
+		encoded: "café",
+		decoded: "café",
+	},
+	{
+		enc:     "ascii",
+		encoded: "hi there",
+		decoded: "hi there",
+	},
+	{
 		enc:     "quoted-printable",
 		encoded: "caf=C3=A9",
 		decoded: "café",
@@ -43,6 +74,141 @@ var testEncodings = []struct {
 		enc:     "iso-8859-1",
 		encoded: "caf" + string([]byte{0xe9}) + " ",
 		decoded: "café ",
+	},
+	{
+		enc:     "windows-1252",
+		encoded: "Hell\xE9, world!",
+		decoded: "Hellé, world!",
+	},
+	{
+		enc:     "cp1252",
+		encoded: "Hell\xE9, world!",
+		decoded: "Hellé, world!",
+	},
+	{
+		enc:     "iso-2022-jp",
+		encoded: "\x1b$B$3$s$K$A$O\x1b(B",
+		decoded: "こんにちは", // "hello" in Japanese
+	},
+	{
+		enc:     "iso-8859-14",
+		encoded: "\xA1ello, world!",
+		decoded: "Ḃello, world!",
+	},
+	{
+		enc:     "ansi_x3.4-1968",
+		encoded: "Hello, world!", // This encoding is the same as ascii, but with some revisions
+		decoded: "Hello, world!",
+	},
+	{
+		enc:     "iso-8859-2",
+		encoded: "Hello, World! \xbf\xf3\xbb\xea",
+		decoded: "Hello, World! żóťę",
+	},
+	{
+		enc:     "windows-1251",
+		encoded: "Hello, World! \xbf\xf3\xbb\xea",
+		decoded: "Hello, World! їу»к",
+	},
+	{
+		enc:     "windows-1256",
+		encoded: "Hello, World! \xbf\xf3\xbb\xea",
+		decoded: "Hello, World! ؟َ»ê",
+	},
+	{
+		enc:     "koi8-u",
+		encoded: "Hello, World! \xbf\xf3\xbb\xea",
+		decoded: "Hello, World! ©С╩Й",
+	},
+	{
+		enc:     "ks_c_5601-1987",
+		encoded: "\xbeȳ\xe7\xc7ϼ\xbc\xbf\xe4",
+		decoded: "안녕하세요", // "hello" in Korean
+	},
+	{
+		enc:     "gbk",
+		encoded: "\xc4\xe3\xba\xc3",
+		decoded: "你好", // "hello" in Chinese
+	},
+	{
+		enc:     "iso-8859-6",
+		encoded: "Hello, World! \xbf\xea",
+		decoded: "Hello, World! ؟ي", // Arabic question mark
+	},
+	{
+		enc:     "windows-1257",
+		encoded: "Hello, World! \xfe\xe0\xe8\xe6\xeb\xe1\xf0\xf8\xfb",
+		decoded: "Hello, World! žąčęėįšųū", // Lithuanian
+	},
+	{
+		enc:     "windows-1250",
+		encoded: "\xd8\xedkej, \x9ee t\xec l\xe1ska k \x9eivotu nedovol\xed lh\xe1t.",
+		decoded: "Říkej, že tě láska k životu nedovolí lhát.", // Czech
+	},
+	{
+		enc:     "gb2312",
+		encoded: "\xc4\xe3\xba\xc3",
+		decoded: "你好", // "hello" in Chinese
+	},
+	{
+		enc:     "iso-8859-8-i",
+		encoded: "\xf9\xec\xe5\xed, \xee\xe4 \xf9\xec\xe5\xee\xea?",
+		decoded: "שלום, מה שלומך?", // Hebrew, "hello, how are you?"
+	},
+	{
+		enc:     "windows-1258",
+		encoded: "Ch\xe0o",
+		decoded: "Chào", // Vietnamese, "hello"
+	},
+	{
+		enc:     "big5",
+		encoded: "\xd2\xf1\xc2k\xbf\xa4",
+		decoded: "秭歸縣", // Chinese, "Zigui County"
+	},
+	{
+		enc:     "windows-1255",
+		encoded: "\xf9\xec\xe5\xed, \xee\xe4 \xf9\xec\xe5\xee\xea?",
+		decoded: "שלום, מה שלומך?", // Hebrew, "hello, how are you?"
+	},
+	{
+		enc:     "windows-1253",
+		encoded: "\xca\xe1\xeb\xe7\xec\xdd\xf1\xe1 \xea\xfc\xf3\xec\xe5!",
+		decoded: "Καλημέρα κόσμε!", // Greek, "Good morning world!"
+	},
+	{
+		enc:     "iso-8859-9",
+		encoded: "Merhaba d\xfcnya!",
+		decoded: "Merhaba dünya!", // Turkish, "hello world!"
+	},
+	{
+		enc:     "windows-1254",
+		encoded: "Merhaba d\xfcnya!",
+		decoded: "Merhaba dünya!", // Turkish, "hello world!"
+	},
+	{
+		enc:     "shift-jis",
+		encoded: "\x82\xb1\x82\xf1\x82ɂ\xbf\x82\xcd",
+		decoded: "こんにちは", // "hello" in Japanese
+	},
+	{
+		enc:     "utf-16le",
+		encoded: "H\x00e\x00l\x00l\x00o\x00,\x00 \x00w\x00o\x00r\x00l\x00d\x00!\x00 \x00=\xd8\x00\xde",
+		decoded: "Hello, world! 😀",
+	},
+	{
+		enc:     "iso-8859-5",
+		encoded: "\xbf\xe0\xd8\xd2\xd5\xe2, \xdc\xd8\xe0!",
+		decoded: "Привет, мир!", // Russian, "hello world!"
+	},
+	{
+		enc:     "iso-8859-7",
+		encoded: "\xca\xe1\xeb\xe7\xec\xdd\xf1\xe1, \xea\xfc\xf3\xec\xe5!",
+		decoded: "Καλημέρα, κόσμε!", // Greek, "good morning, world!"
+	},
+	{
+		enc:     "iso_8859-1",
+		encoded: "caf\xe9",
+		decoded: "café",
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/emersion/go-message
 
 go 1.14
 
-require golang.org/x/text v0.14.0
+require (
+	github.com/stretchr/testify v1.9.0
+	golang.org/x/text v0.14.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
@@ -30,3 +44,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Hello @emersion ,

Can I add support to iso-8859-1 encoding? I saw this encoding is supported in `charset.go`, but not `encoding.go`: https://github.com/emersion/go-message/blob/master/charset/charset.go#L27

I am fairly new to this library. Please let me know if I need to make more changes to support iso-8859-1.

ps: Can I add some more encodings? I can do it as part of this PR.

Thank you.

Zhi Qu