### PR TITLE
Adds support of multipart/related for inline attachments

### DIFF
--- a/mail/attachment.go
+++ b/mail/attachment.go
@@ -4,13 +4,8 @@ import (
 	"github.com/emersion/go-message"
 )
 
-// An AttachmentHeader represents an attachment's header.
-type AttachmentHeader struct {
-	message.Header
-}
-
-// Filename parses the attachment's filename.
-func (h *AttachmentHeader) Filename() (string, error) {
+// parseFilename parses the filename from the header.
+func parseFilename(h message.Header) (string, error) {
 	_, params, err := h.ContentDisposition()
 
 	filename, ok := params["filename"]
@@ -23,8 +18,34 @@ func (h *AttachmentHeader) Filename() (string, error) {
 	return filename, err
 }
 
+// An AttachmentHeader represents an attachment's header.
+type AttachmentHeader struct {
+	message.Header
+}
+
+// Filename parses the attachment's filename.
+func (h *AttachmentHeader) Filename() (string, error) {
+	return parseFilename(h.Header)
+}
+
 // SetFilename formats the attachment's filename.
 func (h *AttachmentHeader) SetFilename(filename string) {
 	dispParams := map[string]string{"filename": filename}
 	h.SetContentDisposition("attachment", dispParams)
+}
+
+// An InlineAttachmentHeader represents an inlined attachment's header.
+type InlineAttachmentHeader struct {
+	message.Header
+}
+
+// Filename parses the attachment's filename.
+func (h *InlineAttachmentHeader) Filename() (string, error) {
+	return parseFilename(h.Header)
+}
+
+// SetFilename formats the attachment's filename.
+func (h *InlineAttachmentHeader) SetFilename(filename string) {
+	dispParams := map[string]string{"filename": filename}
+	h.SetContentDisposition("inline", dispParams)
 }

--- a/mail/attachment_test.go
+++ b/mail/attachment_test.go
@@ -49,3 +49,14 @@ func TestAttachmentHeader_Filename_encoded(t *testing.T) {
 		t.Errorf("Expected filename to be %q but got %q", "", filename)
 	}
 }
+
+func TestInlineAttachmentHeader_Filename(t *testing.T) {
+	var h mail.InlineAttachmentHeader
+	h.Set("Content-Disposition", "inline; filename=note.txt")
+
+	if filename, err := h.Filename(); err != nil {
+		t.Error("Expected no error while parsing filename, got:", err)
+	} else if filename != "note.txt" {
+		t.Errorf("Expected filename to be %q but got %q", "note.txt", filename)
+	}
+}

--- a/mail/writer.go
+++ b/mail/writer.go
@@ -33,6 +33,16 @@ func initAttachmentHeader(h *AttachmentHeader) {
 	}
 }
 
+func initInlineAttachmentHeader(h *InlineAttachmentHeader) {
+	disp, _, _ := h.ContentDisposition()
+	if disp != "inline" {
+		h.Set("Content-Disposition", "inline")
+	}
+	if !h.Has("Content-Transfer-Encoding") {
+		h.Set("Content-Transfer-Encoding", "base64")
+	}
+}
+
 // A Writer writes a mail message. A mail message contains one or more text
 // parts and zero or more attachments.
 type Writer struct {
@@ -77,6 +87,20 @@ func CreateSingleInlineWriter(w io.Writer, header Header) (io.WriteCloser, error
 	return message.CreateWriter(w, header.Header)
 }
 
+// CreateRelatedWriter writes a mail header to w. The mail will contain an
+// inline part and any inline attachments. Non-inline attachments cannot be added.
+func CreateRelatedWriter(w io.Writer, header Header) (*RelatedWriter, error) {
+	header = header.Copy() // don't modify the caller's view
+	header.Set("Content-Type", "multipart/related")
+
+	mw, err := message.CreateWriter(w, header.Header)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RelatedWriter{mw}, nil
+}
+
 // CreateInline creates a InlineWriter. One or more parts representing the same
 // text in different formats can be written to a InlineWriter.
 func (w *Writer) CreateInline() (*InlineWriter, error) {
@@ -88,6 +112,20 @@ func (w *Writer) CreateInline() (*InlineWriter, error) {
 		return nil, err
 	}
 	return &InlineWriter{mw}, nil
+}
+
+// CreateRelated created a RelatedWriter. Inline attachments and one or more
+// parts representing the same text in different format can be written to a
+// RelatedWriter.
+func (w *Writer) CreateRelated() (*RelatedWriter, error) {
+	var h message.Header
+	h.Set("Content-Type", "multipart/related")
+
+	mw, err := w.mw.CreatePart(h)
+	if err != nil {
+		return nil, err
+	}
+	return &RelatedWriter{mw}, nil
 }
 
 // CreateSingleInline creates a new single text part with the provided header.
@@ -128,5 +166,46 @@ func (w *InlineWriter) CreatePart(h InlineHeader) (io.WriteCloser, error) {
 
 // Close finishes the InlineWriter.
 func (w *InlineWriter) Close() error {
+	return w.mw.Close()
+}
+
+// RelatedWriter write a mail message with inline attachments and text parts.
+type RelatedWriter struct {
+	mw *message.Writer
+}
+
+// CreateInline creates a InlineWriter. One or more parts representing the same
+// text in different formats can be written to a InlineWriter.
+func (w *RelatedWriter) CreateInline() (*InlineWriter, error) {
+	var h message.Header
+	h.Set("Content-Type", "multipart/alternative")
+
+	mw, err := w.mw.CreatePart(h)
+	if err != nil {
+		return nil, err
+	}
+	return &InlineWriter{mw}, nil
+}
+
+// CreateSingleInline creates a new single text part with the provided header.
+// The body of the part should be written to the returned io.WriteCloser. Only
+// one single text part should be written, use CreateInline if you want multiple
+// text parts.
+func (w *RelatedWriter) CreateSingleInline(h InlineHeader) (io.WriteCloser, error) {
+	h = InlineHeader{h.Header.Copy()} // don't modify the caller's view
+	initInlineHeader(&h)
+	return w.mw.CreatePart(h.Header)
+}
+
+// CreateInlineAttachment creates a new inline attachment with the provided header.
+// The body of the part should be written to the returned io.WriteCloser.
+func (w *RelatedWriter) CreateInlineAttachment(h InlineAttachmentHeader) (io.WriteCloser, error) {
+	h = InlineAttachmentHeader{h.Header.Copy()} // don't modify the caller's view
+	initInlineAttachmentHeader(&h)
+	return w.mw.CreatePart(h.Header)
+}
+
+// Close finishes the RelatedWriter.
+func (w *RelatedWriter) Close() error {
 	return w.mw.Close()
 }

--- a/mail/writer_test.go
+++ b/mail/writer_test.go
@@ -29,7 +29,7 @@ func ExampleWriter() {
 	}
 
 	// Create a text part
-	tw, err := mw.CreateInline()
+	tw, err := mw.CreateAlternative()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func TestWriter(t *testing.T) {
 	}
 
 	// Create a text part
-	tw, err := mw.CreateInline()
+	tw, err := mw.CreateAlternative()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR adds support for multipart/related to the mail package by introducing a new `RelatedWriter` and corresponding methods to the package. See #179 for more information about the usecases.


This PR also renames existing functions and methods to make the wording more uniform. In detail, the following renamings have been added:

* `InlineWriter` to `AlternativeWriter` to represent its task of writing "multipart/alternative", the same way like the new `RelatedWriter` writes "multipart/related".
* `CreateInlineWriter()` to `CreateAlternativeWriter()` to match the renaming of the returned writer.
* `Writer.CreateInline()` to `Writer.CreateAlternative()` to match the renaming of the returned writer.

The old namings are still in-place and marked as deprecated, so this PR does not introduce a BC break.