### PR TITLE
message: DecodeTextAttachments option (FR #182)

### DIFF
--- a/charset.go
+++ b/charset.go
@@ -64,3 +64,29 @@ func decodeHeader(s string) (string, error) {
 func encodeHeader(s string) string {
 	return mime.QEncoding.Encode("utf-8", s)
 }
+
+// DecodeTextAttachments turns on charset decoding to UTF-8 for all multipart
+// `text/*` parts. It is `true` by default for backward compatibility. All
+// `text/*` parts either `inline` or `attachment` Content-Disposition will be
+// decoded to UTF-8. This may cause data corruption for incorrect or invalid
+// emails, for example when defined charset doesn't match actual charset.
+//
+// When set to `false`, the `text/*` parts with Content-Disposition set to
+// `attachment` will NOT be decoded and will be returned "as is".
+//
+// https://github.com/emersion/go-message/issues/182
+var DecodeTextAttachments = true
+
+// needDecodeTextPart returns whether we need to decode text/* part to UTF-8
+//
+// https://github.com/emersion/go-message/issues/182
+func needDecodeTextPart(header Header) bool {
+	if DecodeTextAttachments {
+		return true
+	}
+	disposition, _, err := header.ContentDisposition()
+	if err == nil && disposition == "attachment" {
+		return false
+	}
+	return true
+}

--- a/entity.go
+++ b/entity.go
@@ -46,7 +46,7 @@ func New(header Header, body io.Reader) (*Entity, error) {
 	}
 
 	// RFC 2046 section 4.1.2: charset only applies to text/*
-	if strings.HasPrefix(mediaType, "text/") {
+	if strings.HasPrefix(mediaType, "text/") && needDecodeTextPart(header) {
 		if ch, ok := mediaParams["charset"]; ok {
 			if converted, charsetErr := charsetReader(ch, body); charsetErr != nil {
 				err = UnknownCharsetError{charsetErr}


### PR DESCRIPTION
Implements #182.

A package level option variable added as the simpliest way for static app-level setup:
```go
import (
    "github.com/emersion/go-message"
)

func init() {
    message.DecodeTextAttachments = false
}
```

A test case exists in [feat/182-text-attachments-charset-decode-test](https://github.com/Vovan-VE/go-message/tree/feat/182-text-attachments-charset-decode-test) (commit https://github.com/Vovan-VE/go-message/commit/dc96a3f7938245d1a93db0a886d6e0591f1f0449) but not included here because it's potentially parallel unsafe because of simple package level variable.