### PR TITLE
Fixup line wrapper short write bug

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -125,10 +125,11 @@ func (w *lineWrapper) Write(b []byte) (int, error) {
 		if cr {
 			ending = []byte("\n")
 		}
-		_, err = w.w.Write(ending)
+		n, err = w.w.Write(ending)
 		if err != nil {
 			return written, err
 		}
+		written += n
 		w.cr = false
 	}
 

--- a/encoding.go
+++ b/encoding.go
@@ -125,11 +125,14 @@ func (w *lineWrapper) Write(b []byte) (int, error) {
 		if cr {
 			ending = []byte("\n")
 		}
-		n, err = w.w.Write(ending)
+		_, err = w.w.Write(ending)
 		if err != nil {
 			return written, err
 		}
-		written += n
+		// If the written `\n` was part of the input bytes slice, then account for it.
+		if lf {
+			written++
+		}
 		w.cr = false
 	}
 


### PR DESCRIPTION
TL;DR, without this patch, the following test would not pass:

```go
func TestLineWrapperShortWrite(t *testing.T) {
    var sb strings.Builder
    w := &lineWrapper{w: &sb, maxLineLen: 76}

    b := []byte("The end.\r\n")
    n, err := w.Write(b)
    if err != nil {
        t.Fatalf("Write() = %v", err)
    }

    if n != len(b) {
        // FAILS HERE.
        t.Errorf("Written = %d, want %d", n, len(b))
    }
}
```

This is known as `io.ErrShortWrite`; I encountered it in `bytes.Reader.WriteTo` (via `io.Copy`):

```go
package bytes

...

// WriteTo implements the [io.WriterTo] interface.
func (r *Reader) WriteTo(w io.Writer) (n int64, err error) {
	r.prevRune = -1
	if r.i >= int64(len(r.s)) {
		return 0, nil
	}
	b := r.s[r.i:]
	m, err := w.Write(b)
	if m > len(b) {
		panic("bytes.Reader.WriteTo: invalid Write count")
	}
	r.i += int64(m)
	n = int64(m)
	if m != len(b) && err == nil {
		err = io.ErrShortWrite
	}
	return
}

...
```