### PR TITLE
Fix typo in the doc for (*Header).AddRaw method.

### DIFF
--- a/textproto/header.go
+++ b/textproto/header.go
@@ -102,7 +102,7 @@ func HeaderFromMap(m map[string][]string) Header {
 // AddRaw adds the raw key, value pair to the header.
 //
 // The supplied byte slice should be a complete field in the "Key: Value" form
-// including trailing CRLF. If there is no comma in the input - AddRaw panics.
+// including trailing CRLF. If there is no colon in the input - AddRaw panics.
 // No changes are made to kv contents and it will be copied into WriteHeader
 // output as is.
 //


### PR DESCRIPTION
The doc incorrectly stated that the method requires the argument to have a comma character. Instead, it requires a colon.